### PR TITLE
feat: add k8s

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,24 @@
+include:
+  - project: SocialGouv/gitlab-ci-yml
+    file: /autodevops.yml
+    ref: v20.7.9
+
+variables:
+  AUTO_DEVOPS_KANIKO: "✔️"
+  AUTO_DEVOPS_RELEASE_AUTO: "✔️"
+  AUTO_DEVOPS_PRODUCTION_AUTO: "✔️"
+  AUTO_DEVOPS_ENABLE_KAPP: "✔️"
+  AUTO_DEVOPS_TEST_DISABLED: "🛑"
+  AUTO_DEVOPS_QUALITY_DISABLED: "🛑"
+  AUTO_DEVOPS_NOTIFY_DISABLED: "🛑"
+
+Build:
+  stage: Code Quality
+  script:
+    - echo "No build, ma"
+
+Register Kaniko image:
+  extends: .autodevops_register_kaniko_image
+  variables:
+    CONTEXT: front
+    IMAGE_NAME: les1000jours-front

--- a/.socialgouv/config.json
+++ b/.socialgouv/config.json
@@ -1,0 +1,6 @@
+{
+  "name": "les1000jours-front",
+  "type": "app",
+  "subdomain": "les1000jours-front",
+  "probesPath": "/"
+}

--- a/front/.dockerignore
+++ b/front/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:15-alpine
+FROM node:15-alpine as builder
 
 WORKDIR /app
 
@@ -9,12 +9,17 @@ COPY yarn.lock .
 
 ENV NODE_ENV=production
 
-RUN yarn install --production --frozen-lockfile
+# need expo-cli and typescript@~4.0.0 @types/react@~16.9.35
+RUN yarn install --frozen-lockfile
+RUN yarn global add expo-cli
+RUN yarn add --dev typescript@~4.0.0 @types/react@~16.9.35 @types/react-native@~0.63.2
 
 COPY . .
 
-RUN cd /front
+RUN yarn expo build:web
 
-USER node
+FROM registry.gitlab.factory.social.gouv.fr/socialgouv/docker/nginx4spa:4.6.1
 
-ENTRYPOINT ["yarn", "start"]
+COPY --from=builder /app/web-build /usr/share/nginx/html
+
+ENV PORT 3000


### PR DESCRIPTION
Add a [gitlab AutoDevOps pipeline](https://github.com/SocialGouv/gitlab-ci-yml/#autodevops) :

 - deploy a new url for the new branches
 - `AUTO_DEVOPS_RELEASE_AUTO` trigger semantic-release when merge on master
 - `AUTO_DEVOPS_PRODUCTION_AUTO` deploys to production on new release

The Dockerfile build the web version and use nginx to expose it

demo : https://k8s-dev2-1000jours.dev2.fabrique.social.gouv.fr/one