### PR TITLE
fix(build): corrige le build du backoffice

### DIFF
--- a/back/strapi/Dockerfile
+++ b/back/strapi/Dockerfile
@@ -11,6 +11,7 @@ COPY . .
 
 ENV NODE_ENV production
 
+RUN yarn build-ts
 RUN yarn build
 
 CMD ["yarn", "start"]


### PR DESCRIPTION
Le dossier `strapi/api-src` doit être transformé en fichiers js vers `strapi/api` au build de l'image.