### PR TITLE
fix(k8s): fix PVC issue with kube 1.19

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,18 +12,13 @@ variables:
   AUTO_DEVOPS_QUALITY_DISABLED: "🛑"
   AUTO_DEVOPS_NOTIFY_DISABLED: "🛑"
 
-# Lint:
-#   script:
-#     - cd front
-#     - yarn lint
+Lint:
+  rules:
+    - when: never
 
-# Build:
-#   script:
-#     - apk add --no-cache bash
-#     - cd front
-#     - yarn
-#     - yarn expo-login
-#     - yarn publish-staging
+Build:
+  rules:
+    - when: never
 
 K8S Test:
   extends: .autodevops_k8s_test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,18 +12,18 @@ variables:
   AUTO_DEVOPS_QUALITY_DISABLED: "🛑"
   AUTO_DEVOPS_NOTIFY_DISABLED: "🛑"
 
-Lint:
-  script:
-    - cd front
-    - yarn lint
+# Lint:
+#   script:
+#     - cd front
+#     - yarn lint
 
-Build:
-  script:
-    - apk add --no-cache bash
-    - cd front
-    - yarn
-    - yarn expo-login
-    - yarn publish-staging
+# Build:
+#   script:
+#     - apk add --no-cache bash
+#     - cd front
+#     - yarn
+#     - yarn expo-login
+#     - yarn publish-staging
 
 K8S Test:
   extends: .autodevops_k8s_test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,7 @@ Build:
   rules:
     - when: never
 
+
 K8S Test:
   extends: .autodevops_k8s_test
   rules:

--- a/.k8s/__tests__/__snapshots__/dev.ts.snap
+++ b/.k8s/__tests__/__snapshots__/dev.ts.snap
@@ -602,10 +602,8 @@ spec:
               cpu: 5m
               memory: 16Mi
       volumes:
-        - azureFile:
-            readOnly: false
-            secretName: strapi-sealed-secret
-            shareName: uploads
+        - persistentVolumeClaim:
+            claimName: strapi-uploads
           name: uploads
 ---
 apiVersion: bitnami.com/v1alpha1
@@ -726,5 +724,38 @@ spec:
     - hosts:
         - backoffice-chore-d-u8fps8-les1000jours.dev2.fabrique.social.gouv.fr
       secretName: wildcard-crt
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: strapi-uploads
+  labels:
+    usage: strapi-uploads
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  azureFile:
+    secretName: strapi-sealed-secret
+    shareName: uploads
+    readOnly: false
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: strapi-uploads
+  annotations:
+    volume.beta.kubernetes.io/storage-class: ''
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi
+  selector:
+    matchLabels:
+      usage: strapi-uploads
 "
 `;

--- a/.k8s/__tests__/__snapshots__/dev.ts.snap
+++ b/.k8s/__tests__/__snapshots__/dev.ts.snap
@@ -603,7 +603,7 @@ spec:
               memory: 16Mi
       volumes:
         - persistentVolumeClaim:
-            claimName: strapi-uploads
+            claimName: strapi-uploads2
           name: uploads
 ---
 apiVersion: bitnami.com/v1alpha1
@@ -728,9 +728,9 @@ spec:
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: strapi-uploads
+  name: strapi-uploads2
   labels:
-    usage: strapi-uploads
+    usage: strapi-uploads2
 spec:
   capacity:
     storage: 50Gi
@@ -746,7 +746,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: strapi-uploads
+  name: strapi-uploads2
   annotations:
     volume.beta.kubernetes.io/storage-class: ''
 spec:
@@ -757,6 +757,6 @@ spec:
       storage: 10Gi
   selector:
     matchLabels:
-      usage: strapi-uploads
+      usage: strapi-uploads2
 "
 `;

--- a/.k8s/__tests__/__snapshots__/dev.ts.snap
+++ b/.k8s/__tests__/__snapshots__/dev.ts.snap
@@ -733,12 +733,13 @@ metadata:
     usage: strapi-uploads
 spec:
   capacity:
-    storage: 10Gi
+    storage: 50Gi
   accessModes:
     - ReadWriteMany
   persistentVolumeReclaimPolicy: Retain
   azureFile:
     secretName: strapi-sealed-secret
+    secretNamespace: 1000jours-85-master-dev2
     shareName: uploads
     readOnly: false
 ---

--- a/.k8s/__tests__/__snapshots__/preprod.ts.snap
+++ b/.k8s/__tests__/__snapshots__/preprod.ts.snap
@@ -564,7 +564,7 @@ spec:
               memory: 16Mi
       volumes:
         - persistentVolumeClaim:
-            claimName: strapi-uploads
+            claimName: strapi-uploads2
           name: uploads
 ---
 apiVersion: bitnami.com/v1alpha1
@@ -689,9 +689,9 @@ spec:
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: strapi-uploads
+  name: strapi-uploads2
   labels:
-    usage: strapi-uploads
+    usage: strapi-uploads2
 spec:
   capacity:
     storage: 50Gi
@@ -707,7 +707,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: strapi-uploads
+  name: strapi-uploads2
   annotations:
     volume.beta.kubernetes.io/storage-class: ''
 spec:
@@ -718,6 +718,6 @@ spec:
       storage: 10Gi
   selector:
     matchLabels:
-      usage: strapi-uploads
+      usage: strapi-uploads2
 "
 `;

--- a/.k8s/__tests__/__snapshots__/preprod.ts.snap
+++ b/.k8s/__tests__/__snapshots__/preprod.ts.snap
@@ -563,10 +563,8 @@ spec:
               cpu: 5m
               memory: 16Mi
       volumes:
-        - azureFile:
-            readOnly: false
-            secretName: strapi-sealed-secret
-            shareName: uploads
+        - persistentVolumeClaim:
+            claimName: strapi-uploads
           name: uploads
 ---
 apiVersion: bitnami.com/v1alpha1
@@ -687,5 +685,38 @@ spec:
     - hosts:
         - backoffice-v1-2-3-les1000jours.dev2.fabrique.social.gouv.fr
       secretName: wildcard-crt
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: strapi-uploads
+  labels:
+    usage: strapi-uploads
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  azureFile:
+    secretName: strapi-sealed-secret
+    shareName: uploads
+    readOnly: false
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: strapi-uploads
+  annotations:
+    volume.beta.kubernetes.io/storage-class: ''
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi
+  selector:
+    matchLabels:
+      usage: strapi-uploads
 "
 `;

--- a/.k8s/__tests__/__snapshots__/preprod.ts.snap
+++ b/.k8s/__tests__/__snapshots__/preprod.ts.snap
@@ -694,12 +694,13 @@ metadata:
     usage: strapi-uploads
 spec:
   capacity:
-    storage: 10Gi
+    storage: 50Gi
   accessModes:
     - ReadWriteMany
   persistentVolumeReclaimPolicy: Retain
   azureFile:
     secretName: strapi-sealed-secret
+    secretNamespace: 1000jours-85-preprod-dev2
     shareName: uploads
     readOnly: false
 ---

--- a/.k8s/__tests__/__snapshots__/prod.ts.snap
+++ b/.k8s/__tests__/__snapshots__/prod.ts.snap
@@ -543,7 +543,7 @@ spec:
               memory: 16Mi
       volumes:
         - persistentVolumeClaim:
-            claimName: strapi-uploads
+            claimName: strapi-uploads2
           name: uploads
 ---
 apiVersion: bitnami.com/v1alpha1
@@ -667,9 +667,9 @@ spec:
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: strapi-uploads
+  name: strapi-uploads2
   labels:
-    usage: strapi-uploads
+    usage: strapi-uploads2
 spec:
   capacity:
     storage: 50Gi
@@ -685,7 +685,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: strapi-uploads
+  name: strapi-uploads2
   annotations:
     volume.beta.kubernetes.io/storage-class: ''
 spec:
@@ -696,6 +696,6 @@ spec:
       storage: 10Gi
   selector:
     matchLabels:
-      usage: strapi-uploads
+      usage: strapi-uploads2
 "
 `;

--- a/.k8s/__tests__/__snapshots__/prod.ts.snap
+++ b/.k8s/__tests__/__snapshots__/prod.ts.snap
@@ -672,12 +672,13 @@ metadata:
     usage: strapi-uploads
 spec:
   capacity:
-    storage: 10Gi
+    storage: 50Gi
   accessModes:
     - ReadWriteMany
   persistentVolumeReclaimPolicy: Retain
   azureFile:
     secretName: strapi-sealed-secret
+    secretNamespace: les1000jours
     shareName: uploads
     readOnly: false
 ---

--- a/.k8s/__tests__/__snapshots__/prod.ts.snap
+++ b/.k8s/__tests__/__snapshots__/prod.ts.snap
@@ -542,10 +542,8 @@ spec:
               cpu: 5m
               memory: 16Mi
       volumes:
-        - azureFile:
-            readOnly: false
-            secretName: strapi-sealed-secret
-            shareName: uploads
+        - persistentVolumeClaim:
+            claimName: strapi-uploads
           name: uploads
 ---
 apiVersion: bitnami.com/v1alpha1
@@ -665,5 +663,38 @@ spec:
     - hosts:
         - backoffice-les1000jours.fabrique.social.gouv.fr
       secretName: strapi-crt
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: strapi-uploads
+  labels:
+    usage: strapi-uploads
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  azureFile:
+    secretName: strapi-sealed-secret
+    shareName: uploads
+    readOnly: false
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: strapi-uploads
+  annotations:
+    volume.beta.kubernetes.io/storage-class: ''
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi
+  selector:
+    matchLabels:
+      usage: strapi-uploads
 "
 `;

--- a/.k8s/components/strapi.ts
+++ b/.k8s/components/strapi.ts
@@ -85,6 +85,8 @@ const strapiManifests = create("strapi", {
 //@ts-expect-error
 const deployment = getManifestByKind(strapiManifests, Deployment) as Deployment;
 
+const namespace = deployment?.metadata?.namespace;
+
 if (deployment && deployment?.spec?.template.spec) {
   deployment.spec.template.spec.volumes = [
     {
@@ -105,12 +107,13 @@ const pv = new PersistentVolume({
   },
   spec: {
     capacity: {
-      storage: "10Gi",
+      storage: "50Gi",
     },
     accessModes: ["ReadWriteMany"],
     persistentVolumeReclaimPolicy: "Retain",
     azureFile: {
       secretName: "strapi-sealed-secret",
+      secretNamespace: namespace,
       shareName: "uploads",
       readOnly: false,
     },

--- a/.k8s/components/strapi.ts
+++ b/.k8s/components/strapi.ts
@@ -91,7 +91,7 @@ if (deployment && deployment?.spec?.template.spec) {
   deployment.spec.template.spec.volumes = [
     {
       persistentVolumeClaim: {
-        claimName: "strapi-uploads",
+        claimName: "strapi-uploads2",
       },
       name: "uploads",
     },
@@ -100,9 +100,9 @@ if (deployment && deployment?.spec?.template.spec) {
 
 const pv = new PersistentVolume({
   metadata: {
-    name: "strapi-uploads",
+    name: "strapi-uploads2",
     labels: {
-      usage: "strapi-uploads",
+      usage: "strapi-uploads2",
     },
   },
   spec: {
@@ -122,7 +122,7 @@ const pv = new PersistentVolume({
 
 const pvc = new PersistentVolumeClaim({
   metadata: {
-    name: "strapi-uploads",
+    name: "strapi-uploads2",
     annotations: {
       "volume.beta.kubernetes.io/storage-class": "",
     },
@@ -136,7 +136,7 @@ const pvc = new PersistentVolumeClaim({
     },
     selector: {
       matchLabels: {
-        usage: "strapi-uploads",
+        usage: "strapi-uploads2",
       },
     },
   },


### PR DESCRIPTION
due to some regression in kubernetes and azure volumes we have to add two new resources to the k8s deployment

some references

https://github.com/kubernetes/kubernetes/issues/99061
https://github.com/kubernetes/examples/tree/master/staging/volumes/azure_file#mount-volume-via-pv-and-pvc
