### PR TITLE
fix(hasura): fix migrations

### DIFF
--- a/back/hasura/migrations/1614770546376_1000jours/up.sql
+++ b/back/hasura/migrations/1614770546376_1000jours/up.sql
@@ -34,8 +34,3 @@ ALTER TABLE "public"."articles_thematiques__thematiques_articles"
     REFERENCES "public"."thematiques"
     ("id") ON UPDATE CASCADE ON DELETE CASCADE;
 
-ALTER TABLE "public"."upload_file_morph"
-    ADD CONSTRAINT "upload_file_morph_upload_file_id_fkey"
-    FOREIGN KEY ("upload_file_id")
-    REFERENCES "public"."upload_file"
-    ("id") ON UPDATE CASCADE ON DELETE CASCADE;

--- a/back/hasura/migrations/1614770546377_1000jours/up.sql
+++ b/back/hasura/migrations/1614770546377_1000jours/up.sql
@@ -1,0 +1,6 @@
+
+ALTER TABLE "public"."upload_file_morph"
+    ADD CONSTRAINT "upload_file_morph_upload_file_id_fkey"
+    FOREIGN KEY ("upload_file_id")
+    REFERENCES "public"."upload_file"
+    ("id") ON UPDATE CASCADE ON DELETE CASCADE;

--- a/back/hasura/migrations/1614770546377_1000jours/up.sql
+++ b/back/hasura/migrations/1614770546377_1000jours/up.sql
@@ -1,4 +1,5 @@
 
+ALTER TABLE "public"."upload_file_morph" DROP CONSTRAINT IF EXISTS "upload_file_morph_upload_file_id_fkey";
 ALTER TABLE "public"."upload_file_morph"
     ADD CONSTRAINT "upload_file_morph_upload_file_id_fkey"
     FOREIGN KEY ("upload_file_id")


### PR DESCRIPTION
Je n'avais pas fait attention /o\ dans la dernière PR avec les migrations

Une fois qu'un fichier de migration a été appliqué sur une base de données, il ne faut plus le modifier, mais créer un nouveau fichier de migration. Sinon, au démarrage, hasura, qui se base sur le nom du fichier ne joue pas le changement et du coup l'état de la base Postgres n'est plus cohérent avec ce qui est défini dans metadata/tables.yml.

Cette PR restaure la migration originale et ajoute une nouvelle migration avec le diff