### PR TITLE
fix(gitlab): update to SocialGouv/gitlab-ci-yml@v21.0.2

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 include:
   - project: SocialGouv/gitlab-ci-yml
     file: /autodevops.yml
-    ref: v20.7.14
+    ref: v21.0.2
 
 variables:
   AUTO_DEVOPS_KANIKO: "✔️"


### PR DESCRIPTION
<img width=100% src=https://media.giphy.com/media/HbAjfmakJTdDuhcsaA/giphy.gif />

---

Will fix broken `Stop review` jobs with missing `kapp` command
see https://github.com/SocialGouv/gitlab-ci-yml/releases/tag/v21.0.2