### PR TITLE
feat(carto): ajoute les POIs et le geocodage des adresses

### DIFF
--- a/back/strapi/api/cartographie-data/config/routes.json
+++ b/back/strapi/api/cartographie-data/config/routes.json
@@ -1,0 +1,52 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/cartographie-data",
+      "handler": "cartographie-data.find",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/cartographie-data/count",
+      "handler": "cartographie-data.count",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/cartographie-data/:id",
+      "handler": "cartographie-data.findOne",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/cartographie-data",
+      "handler": "cartographie-data.create",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "PUT",
+      "path": "/cartographie-data/:id",
+      "handler": "cartographie-data.update",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/cartographie-data/:id",
+      "handler": "cartographie-data.delete",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}

--- a/back/strapi/api/cartographie-data/models/cartographie-data.settings.json
+++ b/back/strapi/api/cartographie-data/models/cartographie-data.settings.json
@@ -1,0 +1,29 @@
+{
+  "kind": "collectionType",
+  "collectionName": "cartographie_data",
+  "info": {
+    "name": "Cartographie Data",
+    "description": ""
+  },
+  "options": {
+    "increments": true,
+    "timestamps": false,
+    "draftAndPublish": false
+  },
+  "attributes": {
+    "identifiant": {
+      "type": "string",
+      "unique": true
+    },
+    "data": {
+      "type": "json"
+    },
+    "cartographie_source": {
+      "model": "cartographie-source"
+    },
+    "cartographie_poi": {
+      "via": "cartographie_data",
+      "model": "cartographie-poi"
+    }
+  }
+}

--- a/back/strapi/api/cartographie-geocode/config/routes.json
+++ b/back/strapi/api/cartographie-geocode/config/routes.json
@@ -1,0 +1,52 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/cartographie-geocodes",
+      "handler": "cartographie-geocode.find",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/cartographie-geocodes/count",
+      "handler": "cartographie-geocode.count",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/cartographie-geocodes/:id",
+      "handler": "cartographie-geocode.findOne",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/cartographie-geocodes",
+      "handler": "cartographie-geocode.create",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "PUT",
+      "path": "/cartographie-geocodes/:id",
+      "handler": "cartographie-geocode.update",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/cartographie-geocodes/:id",
+      "handler": "cartographie-geocode.delete",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}

--- a/back/strapi/api/cartographie-geocode/models/cartographie-geocode.js
+++ b/back/strapi/api/cartographie-geocode/models/cartographie-geocode.js
@@ -1,0 +1,46 @@
+"use strict";
+
+const StringService = require("../../string/services");
+const CartographieGeocodeService = require("../services");
+
+const createIdentifiant = ({
+  adresse,
+  code_postal,
+  commune,
+  position_longitude,
+  position_latitude,
+}) =>
+  StringService.slugLower(adresse, code_postal, commune) ||
+  StringService.slugLower(position_longitude, position_latitude);
+
+const beforeSave = async (data) => {
+  // TODO: si adresse ou code_postal ou commune changent
+  // alors, calculer l'identifiant (slug)
+  // puis, chercher en base s'il existe
+  // s'il existe, merge les geocodes
+  //    et basculer les POI du geocode courant vers le geocode mergé
+  // sinon vérifier qu'il y a d'autres POIs atatchées au geocode
+  //   si oui, créer un nouveau
+  //   si non, mettre à jour celui-là
+
+  // TODO: utiliser createIdentifiant
+  const identifiant = createIdentifiant(data);
+
+  console.log(data);
+
+  if (identifiant !== data.identifiant) {
+    data.identifiant = identifiant;
+    data.has_geocode = false;
+
+    return CartographieGeocodeService.updateGeocode(data);
+  }
+};
+
+module.exports = {
+  createIdentifiant,
+
+  lifecycles: {
+    beforeCreate: beforeSave,
+    beforeUpdate: (params, data) => beforeSave(data),
+  },
+};

--- a/back/strapi/api/cartographie-geocode/models/cartographie-geocode.settings.json
+++ b/back/strapi/api/cartographie-geocode/models/cartographie-geocode.settings.json
@@ -1,0 +1,57 @@
+{
+  "kind": "collectionType",
+  "collectionName": "cartographie_geocodes",
+  "info": {
+    "name": "Cartographie Geocode",
+    "description": ""
+  },
+  "options": {
+    "increments": true,
+    "timestamps": false,
+    "draftAndPublish": false
+  },
+  "attributes": {
+    "identifiant": {
+      "type": "string",
+      "unique": true
+    },
+    "adresse": {
+      "type": "string"
+    },
+    "code_postal": {
+      "type": "string"
+    },
+    "commune": {
+      "type": "string"
+    },
+    "position_longitude": {
+      "type": "float"
+    },
+    "position_latitude": {
+      "type": "float"
+    },
+    "has_geocode": {
+      "type": "boolean",
+      "default": false
+    },
+    "geocode_adresse": {
+      "type": "string"
+    },
+    "geocode_code_postal": {
+      "type": "string"
+    },
+    "geocode_commune": {
+      "type": "string"
+    },
+    "geocode_position_longitude": {
+      "type": "float"
+    },
+    "geocode_position_latitude": {
+      "type": "float"
+    },
+    "cartographie_pois": {
+      "collection": "cartographie-poi",
+      "via": "cartographie_geocode"
+    }
+  }
+}

--- a/back/strapi/api/cartographie-geocode/services/batch.js
+++ b/back/strapi/api/cartographie-geocode/services/batch.js
@@ -1,0 +1,260 @@
+const { chain: streamChain } = require("stream-chain");
+const {
+  createGeocodeStream: streamGeocoding,
+  createReverseGeocodeStream: streamReverseGeocoding,
+} = require("addok-geocode-stream");
+
+const CartographieGeocode = require("./");
+
+const GEOCODE_SERVICE_URL = "https://api-adresse.data.gouv.fr";
+
+const knex = (...args) => strapi.connections.default(...args);
+
+const indexifyItems = (items, field) =>
+  items.reduce((index, item) => index.set(item[field], item), new Map());
+
+const pick = (obj, fields) =>
+  fields.reduce((result, field) => ((result[field] = obj[field]), result), {});
+
+const bucketSize = 1000;
+
+const geocodeFields = [
+  "adresse",
+  "code_postal",
+  "commune",
+  "position_longitude",
+  "position_latitude",
+];
+
+const formatGeocode = (data) => {
+  const identifiant = CartographieGeocode.createIdentifiant(data);
+  if (!identifiant) return null;
+
+  return {
+    identifiant,
+    ...pick(data, geocodeFields),
+    geocode: false,
+  };
+};
+
+const indexifyGeocodeIds = (geocodesIds, geocodesIndices) =>
+  geocodesIds.reduce(
+    (result, { id, identifiant }) =>
+      geocodesIndices.get(identifiant).reduce((result, dataIndex) => {
+        result[dataIndex] = id;
+
+        return result;
+      }, result),
+    {}
+  );
+
+const formatAndIndexGeocodes = (dataBuffer) =>
+  dataBuffer
+    .map(({ entity }) => {
+      if (!entity) return null;
+
+      const geocode = formatGeocode(entity);
+      if (!geocode || !geocode.identifiant) return null;
+
+      return geocode;
+    })
+    .filter((geocode) => geocode)
+    .reduce(
+      ({ geocodesMap, geocodesIndices }, geocode, index) => {
+        const { identifiant } = geocode;
+
+        geocodesMap.set(identifiant, geocode);
+
+        const geocodeIndex = geocodesIndices.get(identifiant) || [];
+        geocodeIndex.push(index);
+        geocodesIndices.set(identifiant, geocodeIndex);
+
+        return { geocodesMap, geocodesIndices };
+      },
+      { geocodesMap: new Map(), geocodesIndices: new Map() }
+    );
+
+const updateGeocodePois = async (geocodeId, geocode) => {
+  const geocodeUpdatedFields = geocodeFields.reduce((result, field) => {
+    result[`geocode_${field}`] = geocode[field];
+    return result;
+  }, {});
+
+  const updateFields = {
+    ...geocodeUpdatedFields,
+    cartographie_geocode: geocode.id,
+  };
+
+  await knex("cartographie_pois")
+    .update(updateFields)
+    .where("cartographie_geocode", geocodeId);
+};
+
+const updateGeocode = async (geocode) => {
+  const geocodeInBase = await knex("cartographie_geocodes")
+    .where("identifiant", geocode.identifiant)
+    .first();
+
+  const geocodeId = geocode.id;
+
+  if (geocodeId) {
+    if (geocodeInBase && geocodeInBase.id !== geocodeId) {
+      await knex("cartographie_geocodes").delete().where("id", geocodeId);
+
+      Object.assign(geocodeInBase, geocode);
+
+      geocode.id = geocodeInBase.id;
+    }
+
+    await knex("cartographie_geocodes").update(geocode).where("id", geocode.id);
+
+    await updateGeocodePois(geocodeId, geocode);
+  } else {
+    await upsertAdresse(geocode);
+  }
+};
+
+const formatGeocodeResult = (geocodeResult) => ({
+  id: geocodeResult.id,
+  identifiant: CartographieGeocode.createIdentifiant(geocodeResult),
+
+  geocode_adresse: `${geocodeResult.result_housenumber || ""} ${
+    geocodeResult.result_name || ""
+  }`.trim(),
+
+  geocode_code_postal: geocodeResult.result_postcode || "",
+  geocode_commune: geocodeResult.result_city || "",
+
+  geocode_position_longitude:
+    typeof geocodeResult.longitude === "string"
+      ? +geocodeResult.longitude
+      : null,
+  geocode_position_latitude:
+    typeof geocodeResult.latitude === "string" ? +geocodeResult.latitude : null,
+
+  // TODO: handle 'no result'
+  geocode: true,
+});
+
+const geoStream = (adresses, type = "geocode", options = {}) =>
+  new Promise((resolve, reject) => {
+    const adressesIdentifiantsIndex = indexifyItems(adresses, "identifiant");
+
+    let count = 0;
+
+    const streamCoding =
+      type === "reverse" ? streamReverseGeocoding : streamGeocoding;
+
+    const geocodeStream = streamCoding(GEOCODE_SERVICE_URL, {
+      ...options,
+      resultColumns: [
+        "longitude",
+        "latitude",
+        "result_housenumber",
+        "result_name",
+        "result_postcode",
+        "result_city",
+      ],
+      bucketSize,
+    }).on("error", reject);
+
+    const stream = streamChain([
+      async (result) => {
+        const geocode = formatGeocodeResult(result);
+        if (!geocode) return;
+
+        count += 1;
+
+        await updateGeocode(geocode);
+      },
+    ])
+      .on("error", reject)
+      .on("data", () => {})
+      .on("finish", () => resolve(count));
+
+    geocodeStream.pipe(stream);
+
+    adresses.forEach((adresse) => geocodeStream.write(adresse));
+
+    geocodeStream.end();
+  });
+
+const geocodeAdresses = async (adresses) => {
+  const columns = ["adresse", "code_postal", "commune"];
+
+  adresses = adresses.filter((adresse) =>
+    columns
+      .map((column) => {
+        adresse[column] = adresse[column]
+          ? // fixes geocode API 502 bad gateway error
+            adresse[column].replace(/’/g, "'")
+          : // fixes geocode stream trim() error
+            "";
+
+        return adresse[column];
+      })
+      .join()
+  );
+
+  return geoStream(adresses, "geocode", { columns });
+};
+
+const reverseGeocodeAdresses = async (adresses) =>
+  geoStream(adresses, "reverse", {
+    longitude: "position_longitude",
+    latitude: "position_latitude",
+  });
+
+const fetchAdressesToGeocode = async () => {
+  return knex("cartographie_pois")
+    .select("adresse", "code_postal", "commune")
+    .select(knex.raw("array_agg(id) as pois_ids"))
+    .where("geocode", false)
+    .andWhere((q) => {
+      q.whereNotNull("adresse")
+        .orWhereNotNull("code_postal")
+        .orWhereNotNull("commune");
+    })
+    .groupBy("adresse", "code_postal", "commune")
+    .limit(bucketSize);
+};
+
+const fetchAdressesToReverseGeocode = async () => {
+  return knex("cartographie_pois")
+    .select("position_longitude", "position_latitude")
+    .select(knex.raw("array_agg(id) as pois_ids"))
+    .where("geocode", false)
+    .andWhere((q) => {
+      q.whereNull("adresse")
+        .andWhereNull("code_postal")
+        .andWhereNull("commune");
+    })
+    .groupBy(
+      "position_longitude",
+      "position_latitude",
+      "adresse",
+      "code_postal",
+      "commune"
+    )
+    .limit(bucketSize);
+};
+
+const processMissingGeocodes = async () => {
+  const adresses = await fetchAdressesToGeocode();
+  if (!adresses.length) return 0;
+
+  return geocodeAdresses(adresses);
+};
+
+const processMissingAdresses = async () => {
+  const adresses = await fetchAdressesToReverseGeocode();
+  if (!adresses.length) return 0;
+
+  return reverseGeocodeAdresses(adresses);
+};
+
+module.exports = {
+  updateGeocode,
+  processMissingGeocodes,
+  processMissingAdresses,
+};

--- a/back/strapi/api/cartographie-source/config/routes.json
+++ b/back/strapi/api/cartographie-source/config/routes.json
@@ -1,0 +1,52 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/cartographie-sources",
+      "handler": "cartographie-source.find",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/cartographie-sources/count",
+      "handler": "cartographie-source.count",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/cartographie-sources/:id",
+      "handler": "cartographie-source.findOne",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/cartographie-sources",
+      "handler": "cartographie-source.create",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "PUT",
+      "path": "/cartographie-sources/:id",
+      "handler": "cartographie-source.update",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/cartographie-sources/:id",
+      "handler": "cartographie-source.delete",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}

--- a/back/strapi/api/cartographie-source/models/cartographie-source.js
+++ b/back/strapi/api/cartographie-source/models/cartographie-source.js
@@ -1,0 +1,66 @@
+"use strict";
+
+const StringService = require("../../string/services");
+const StreamService = require("../../stream/services/Stream");
+const CartographieSourcesService = require("../services");
+
+const beforeSave = async (data, hasFileChanged = false) => {
+  data.nom = data.nom.trim();
+
+  data.identifiant = StringService.slugLower(data.nom);
+
+  if (data.regles) {
+    for (const keyRegles of Object.values(data.regles)) {
+      if (!Array.isArray(keyRegles)) continue;
+
+      keyRegles.forEach((regle) => {
+        if (!regle.valeur) return;
+
+        regle.valeur = regle.valeur.trim();
+      });
+    }
+  }
+
+  if (hasFileChanged) {
+    if (data.fichier) {
+      const fichier = await strapi.plugins["upload"].services.upload.fetch({
+        id: data.fichier,
+      });
+
+      data.source = fichier.name;
+
+      const columns = await StreamService.processHeader(fichier);
+
+      if (columns) {
+        data.champs = columns.join("\n");
+      }
+
+      data.version = !data.version ? 1 : data.version + 1;
+    } else {
+      data.source = null;
+      data.champs = null;
+      data.version = null;
+      data.lignes = null;
+      data.traitement = "non_fait";
+      data.pret_a_traiter = false;
+    }
+  }
+};
+
+module.exports = {
+  lifecycles: {
+    beforeCreate: (data) => beforeSave(data, true),
+    beforeUpdate: async (params, data) => {
+      const source = await strapi
+        .query("cartographie-source")
+        .findOne({ id: params.id });
+      if (!source) return;
+
+      const hasFileChanged = source.fichier
+        ? source.fichier.id !== data.fichier
+        : data.fichier !== null;
+
+      await beforeSave(data, hasFileChanged);
+    },
+  },
+};

--- a/back/strapi/api/cartographie-source/models/cartographie-source.settings.json
+++ b/back/strapi/api/cartographie-source/models/cartographie-source.settings.json
@@ -1,0 +1,68 @@
+{
+  "kind": "collectionType",
+  "collectionName": "cartographie_sources",
+  "info": {
+    "name": "Cartographie Source",
+    "description": ""
+  },
+  "options": {
+    "increments": true,
+    "timestamps": true,
+    "draftAndPublish": false
+  },
+  "attributes": {
+    "nom": {
+      "type": "string"
+    },
+    "identifiant": {
+      "type": "string"
+    },
+    "type": {
+      "type": "enumeration",
+      "enum": [
+        "fichier",
+        "api"
+      ],
+      "required": true
+    },
+    "source": {
+      "type": "string"
+    },
+    "fichier": {
+      "model": "file",
+      "via": "related",
+      "allowedTypes": [
+        "files"
+      ],
+      "plugin": "upload",
+      "pluginOptions": {}
+    },
+    "version": {
+      "type": "decimal"
+    },
+    "champs": {
+      "type": "text"
+    },
+    "lignes": {
+      "type": "integer"
+    },
+    "pret_a_traiter": {
+      "type": "boolean",
+      "default": false
+    },
+    "traitement": {
+      "type": "enumeration",
+      "enum": [
+        "non_fait",
+        "en_cours",
+        "fait"
+      ],
+      "default": "non_fait"
+    },
+    "regles": {
+      "type": "component",
+      "repeatable": false,
+      "component": "cartographie.regles-champs"
+    }
+  }
+}

--- a/back/strapi/api/cartographie-source/services/index.js
+++ b/back/strapi/api/cartographie-source/services/index.js
@@ -1,0 +1,202 @@
+"use strict";
+
+const path = require("path");
+
+const StreamService = require("../../stream/services/Stream");
+const StringService = require("../../string/services");
+const ParseService = require("../../parse/services");
+const CartographieCategoriesService = require("../../cartographie-categories/services");
+const CartographieGeocodesService = require("../../cartographie-geocode/services");
+
+const upsertSourceData = async (source, line, poiId, reference) => {
+  const knex = strapi.connections.default;
+
+  const sourceData = {
+    identifiant: StringService.slugLower(source.identifiant, reference),
+    data: line,
+    cartographie_source: source.id,
+    cartographie_poi: poiId,
+  };
+
+  await knex("cartographie_data")
+    .insert(sourceData)
+    .onConflict("identifiant")
+    // TODO: merge quand le merge des entites est fait
+    // .merge();
+    .ignore();
+};
+
+const upsertPoi = async (source, entity, geocodeId) => {
+  const knex = strapi.connections.default;
+
+  entity.cartographie_categorie = CartographieCategoriesService.getCategorie(entity.type);
+  entity.cartographie_geocode = geocodeId;
+
+  const reference = entity.references
+  entity.references = JSON.stringify([
+    {
+      source: source.identifiant,
+      reference,
+    },
+  ]);
+
+  const poi = await knex("cartographie_pois")
+    .select("id")
+    .whereRaw(`?? @> ?`, ["references", entity.references])
+    .first();
+
+  if (poi) {
+    // poi is already in database, skip
+    // TODO: merge
+    return poi.id;
+  }
+
+  const result = await knex("cartographie_pois")
+    .insert(entity)
+    .returning("id");
+
+  return result[0];
+};
+
+const upsertPois = async (source, dataBuffer, geocodesIds) => {
+  const knex = strapi.connections.default;
+
+  console.log(
+    "[insert pois]",
+    dataBuffer.length,
+    "item(s), ex:",
+    dataBuffer[0].entity
+  );
+
+  let index = 0;
+
+  for (const { entity, line } of dataBuffer) {
+    const reference = entity.references;
+
+    const poiId = await upsertPoi(source, entity, geocodesIds[index]);
+
+    await upsertSourceData(source, line, poiId, reference);
+
+    index += 1;
+  }
+};
+
+const insertPoisBuffer = async (source, dataBuffer) => {
+  try {
+    const geocodesIds = await CartographieGeocodesService.upsertAdresses(
+      dataBuffer
+    );
+
+    await upsertPois(source, dataBuffer, geocodesIds);
+  } catch (e) {
+    console.error("[cartographie-source] insert error:", e);
+  }
+};
+
+const formatPoiData = (source, entity) => {
+  if (entity.code_postal && entity.code_postal.length < 5) {
+    entity.code_postal = entity.code_postal.padStart(5, "0");
+  }
+
+  for (const key of ["position_longitude", "position_latitude"]) {
+    // TODO: transform based on pois actual types
+    if (entity[key]) {
+      const n = parseFloat(entity[key]);
+
+      entity[key] = !isNaN(n) ? n : null;
+    }
+  }
+};
+
+const processLine = (source, line, fileType) => {
+  const entity = ParseService.parseLine(source.regles, line, fileType);
+  if (!entity || !entity.type || !entity.references) return null;
+
+  formatPoiData(source, entity);
+
+  return { line, entity };
+};
+
+const BUFFER_BATCH_SIZE = 1000;
+
+const processSource = async (source) => {
+  if (!source.fichier || !source.regles) return;
+
+  const knex = strapi.connections.default;
+
+  await knex("cartographie_sources")
+    .update({ traitement: "en_cours" })
+    .where("id", source.id);
+
+  try {
+    let linesCount = 0;
+
+    const filePath = path.join("public", source.fichier.url);
+
+    await StreamService.processFile(filePath, {
+      batchSize: BUFFER_BATCH_SIZE,
+      lineProcessor: (line, fileType) => processLine(source, line, fileType),
+      bufferProcessor: async (dataBuffer) => {
+        await insertPoisBuffer(source, dataBuffer);
+
+        linesCount += dataBuffer.length;
+
+        console.log(
+          `[cartographie-source] file process "${source.nom}" inserted ${linesCount} item(s)`
+        );
+      },
+    });
+
+    if (linesCount) {
+      await knex("cartographie_sources")
+        .update({ lignes: linesCount })
+        .where("id", source.id);
+    }
+
+    await knex("cartographie_sources")
+      .update({
+        pret_a_traiter: false,
+        traitement: "fait",
+      })
+      .where("id", source.id);
+
+    return true;
+  } catch (e) {
+    console.error(e);
+  }
+
+  return false;
+};
+
+const fetchUnprocessedSource = async () => {
+  const sourceTraitementEncours = await strapi
+    .query("cartographie-source")
+    .findOne({ traitement: "en_cours" });
+
+  // TODO: permettre de reprendre un import si le serveur s'arrête
+  // idées :
+  // - ajouter un champ "still_alive" que remplit le processSource à chaque 1000 items
+  // - enregistrer le process.pid de Node pour le comparer => si diff alors le serveur a redémarré
+  // - enregistrer le numero de ligne du fichier
+  if (sourceTraitementEncours) {
+    console.log("[carto-source] import en cours, aucun traitement");
+    return null;
+  }
+
+  return await strapi
+    .query("cartographie-source")
+    .findOne({ pret_a_traiter: true });
+};
+
+const processUnprocessedSources = async () => {
+  const source = await fetchUnprocessedSource();
+  if (!source) return 0;
+
+  console.log(`[carto-source] traitement de "${source.nom}"`);
+
+  const processed = await processSource(source);
+
+  return +processed;
+};
+
+module.exports = { processUnprocessedSources };

--- a/back/strapi/api/csv/services/index.js
+++ b/back/strapi/api/csv/services/index.js
@@ -1,0 +1,58 @@
+const fs = require("fs");
+const csvtojson = require("csvtojson");
+const { detect: detectDelimiter } = require("csv-string");
+const StreamChain = require("stream-chain");
+const BatchStream = require("batch-stream");
+
+const detectColumns = (string, options) =>
+  new Promise((resolve, reject) => {
+    const stream = csvtojson(options)
+      .on("error", reject)
+      .on("header", (columns) => {
+        stream.end();
+
+        if (!columns || !columns.length)
+          return reject(new Error("impossible error: no header"));
+
+        resolve(columns);
+      })
+      .write(`${string}\n`);
+  });
+
+const readFirstLine = async (filePath) =>
+  new Promise((resolve, reject) => {
+    let line = "";
+    let pos = 0;
+    let index = 0;
+
+    const stream = fs
+      .createReadStream(filePath)
+      .on("data", (data) => {
+        index = data.indexOf("\n");
+
+        line += data.toString();
+
+        index !== -1 ? stream.close() : (pos += data.length);
+      })
+      .on("close", () => resolve(line.slice(0, pos + index)))
+      .on("error", reject);
+  });
+
+const parseHeader = async (filePath, options = {}) => {
+  const line = await readFirstLine(filePath);
+
+  const delimiter = detectDelimiter(line);
+
+  const columns = await detectColumns(line, { ...options, delimiter });
+  if (!columns.length) throw new Error(`${filePath} no columns, abort`);
+
+  return { delimiter, columns };
+};
+
+const getProcessors = async (filePath) => {
+  const { delimiter } = await parseHeader(filePath);
+
+  return [csvtojson({ delimiter, flatKeys: true }, { objectMode: true })];
+};
+
+module.exports = { parseHeader, getProcessors };

--- a/back/strapi/api/file/services/index.js
+++ b/back/strapi/api/file/services/index.js
@@ -1,0 +1,51 @@
+const CsvService = require("../../csv/services");
+const JsonService = require("../../json/services");
+
+const getType = (filePath) => {
+  if (filePath.match(/.csv$/)) return "csv";
+  if (filePath.match(/\.(geo)?json$/)) return "json";
+};
+
+const fileTypeServices = {
+  csv: CsvService,
+  json: JsonService,
+};
+
+const processFileHeader = async (filePath) => {
+  let fileType = getType(filePath);
+  if (!fileType) return {};
+
+  return fileTypeServices[fileType].parseHeader(filePath);
+};
+
+const process = async (
+  filePath,
+  { lineProcessor, bufferProcessor, batchSize }
+) => {
+  const fileType = getType(filePath);
+  if (!fileType) return null;
+
+  return streamProcessFile(filePath, [
+    ...(await fileTypeServices[fileType].getProcessors(filePath)),
+    (line) => lineProcessor(line, fileType),
+    new Batch({ size: batchSize }),
+    (dataBuffer) => bufferProcessor(dataBuffer, fileType),
+  ]);
+};
+
+const getHeader = async (fichier) => {
+  const filePath = path.join("public", fichier.url);
+
+  try {
+    const { columns } = await processFileHeader(filePath);
+    if (columns && columns.length) return columns;
+  } catch (e) {
+    console.error(e);
+  }
+};
+
+module.exports = {
+  getType,
+  process,
+  getColumns,
+};

--- a/back/strapi/api/json/services/index.js
+++ b/back/strapi/api/json/services/index.js
@@ -1,0 +1,40 @@
+const { pick } = require("stream-json/filters/Pick");
+const { parser: jsonStreamParser } = require("stream-json/Parser");
+
+const StreamService = require("../../stream/services");
+
+const getFieldsRecursive = (data, fields = new Set(), path = "") =>
+  Object.keys(data).reduce((fields, key) => {
+    const keyPath = path ? `${path}.${key}` : key;
+
+    if (data[key] && Array.isArray(data[key])) {
+      fields.add(`${keyPath}[]`);
+    } else if (data[key] && typeof data[key] === "object") {
+      getFieldsRecursive(data[key], fields, keyPath);
+    } else {
+      fields.add(keyPath);
+    }
+
+    return fields;
+  }, fields);
+
+const getProcessors = async (filePath) => [
+  jsonStreamParser(),
+  // TODO: gérer si le fichier .json n'est pas un tableau
+  ...(filePath.match(/geojson/) ? [pick({ filter: "features" })] : []),
+  streamArray(),
+  ({ value }) => value,
+];
+
+const parseHeader = async (filePath) => {
+  const columnsSet = new Set();
+
+  await StreamService.streamProcessFile(filePath, [
+    ...(await getProcessors(filePath)),
+    (line) => getFieldsRecursive(line, columnsSet),
+  ]);
+
+  return { columns: [...columnsSet].sort() };
+};
+
+module.exports = { parseHeader, getProcesors };

--- a/back/strapi/api/parse/services/index.js
+++ b/back/strapi/api/parse/services/index.js
@@ -1,0 +1,96 @@
+const toArray = (obj) => (!Array.isArray(obj) ? [obj] : obj);
+
+const getValueDot = (obj, key) =>
+  key.split(".").reduce((obj, key) => obj && obj[key], obj);
+
+const getValue = (obj, key, fileType) =>
+  fileType === "json" ? getValueDot(obj, key) : obj[key];
+
+const checkConditions = (conditions, line, fileType = "csv") =>
+  conditions.every(
+    ({ condition_source, condition_valeur }) =>
+      // TODO: demander si besoin de règles de parsing dans les conditions ?
+      // ex : processValue(condition_source, line, fileType)
+      getValue(line, condition_source, fileType) === condition_valeur
+  );
+
+const processValue = (valeur, line, fileType = "csv") => {
+  let isNumber = false;
+  let value;
+
+  if (valeur[0] === '"') {
+    value = valeur.slice(1, valeur.length - 1);
+  } else if (valeur[0] === "+") {
+    isNumber = true;
+    valeur = valeur.slice(1);
+  } else if (valeur[0] === "/") {
+    let [, key, regExp] = valeur.split("/");
+
+    const reg = new RegExp(regExp);
+
+    const lineValue = getValue(line, key, fileType);
+    if (lineValue) {
+      const match = lineValue.match(reg);
+
+      if (match && match[1]) {
+        value = match[1];
+      }
+    }
+  } else if (valeur.match(/\${[^]+}/)) {
+    value = valeur.replace(/\${[^}]+}/g, (m) => {
+      const key = m.slice(2, m.length - 1);
+
+      // TODO: refaire un processValue si regexp dans ${...}
+      return getValue(line, key, fileType) || "";
+    });
+  } else {
+    value = getValue(line, valeur, fileType);
+  }
+
+  if (Array.isArray(value)) {
+    value = value.join(" ");
+  }
+
+  if (typeof value === "string") {
+    value = value.trim().replace(/\s+/g, " ");
+  }
+
+  if (isNumber) {
+    value += value | 0;
+  }
+
+  return value;
+};
+
+const processRegles = (keyRegles, line, fileType = "csv") => {
+  let value;
+
+  for (const keyRegle of keyRegles) {
+    const { valeur, conditions } = keyRegle;
+
+    if (
+      valeur &&
+      (!conditions || checkConditions(conditions.conditions, line, fileType))
+    ) {
+      value = processValue(valeur, line, fileType);
+
+      if (value !== undefined) break;
+    }
+  }
+
+  return value;
+};
+
+const parseLine = (regles, line, fileType = "csv") => {
+  const data = {};
+
+  for (const key of Object.keys(regles)) {
+    if (key === "id" || !regles[key] || !regles[key].length) continue;
+
+    data[key] = processRegles(regles[key], line, fileType);
+  }
+
+  return data;
+};
+
+module.exports = { parseLine };

--- a/back/strapi/api/stream/services/Stream.js
+++ b/back/strapi/api/stream/services/Stream.js
@@ -1,0 +1,59 @@
+const fs = require("fs");
+const util = require("util");
+const stream = require("stream");
+const { chain: streamChain } = require("stream-chain");
+
+// borrowed from https://github.com/segmentio/batch-stream
+// to fix `instanceof Transform` error of stream-chain
+function Batch(options) {
+  if (!(this instanceof Batch)) return new Batch(options);
+
+  options || (options = {});
+
+  const transformOptions = {
+    objectMode: true,
+  };
+
+  if (options.highWaterMark !== undefined) {
+    transformOptions.highWaterMark = options.highWaterMark;
+  }
+
+  stream.Transform.call(this, transformOptions);
+
+  this.size = options.size || 100;
+  this.batch = [];
+}
+
+util.inherits(Batch, stream.Transform);
+
+Batch.prototype._transform = function (chunk, encoding, callback) {
+  this.batch.push(chunk);
+
+  if (this.batch.length >= this.size) {
+    this.push(this.batch);
+    this.batch = [];
+  }
+
+  callback();
+};
+
+Batch.prototype._flush = function (callback) {
+  if (this.batch.length) {
+    this.push(this.batch);
+    this.batch = [];
+  }
+
+  callback();
+};
+
+const streamProcessFile = (filePath, processors) =>
+  new Promise(async (resolve, reject) => {
+    const stream = streamChain([fs.createReadStream(filePath), ...processors])
+      .on("error", reject)
+      .on("data", () => {})
+      // fixes transform flush last push
+      .on("finish", () => stream.resume())
+      .on("end", () => resolve());
+  });
+
+module.exports = { Batch, streamProcessFile };

--- a/back/strapi/api/string/services/index.js
+++ b/back/strapi/api/string/services/index.js
@@ -1,0 +1,5 @@
+const slugify = require("slugify");
+
+const slugLower = (...strs) => slugify(strs.join(" "), { lower: true });
+
+module.exports = { slugLower };

--- a/back/strapi/components/cartographie/condition_simple.json
+++ b/back/strapi/components/cartographie/condition_simple.json
@@ -1,0 +1,17 @@
+{
+  "collectionName": "components_cartographie_condition_simple",
+  "info": {
+    "name": "condition_simple",
+    "icon": "question-circle",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "condition_source": {
+      "type": "string"
+    },
+    "condition_valeur": {
+      "type": "string"
+    }
+  }
+}

--- a/back/strapi/components/cartographie/conditions_collection.json
+++ b/back/strapi/components/cartographie/conditions_collection.json
@@ -1,0 +1,15 @@
+{
+  "collectionName": "components_cartographie_conditions_collection",
+  "info": {
+    "name": "conditions_collection",
+    "icon": "align-left"
+  },
+  "options": {},
+  "attributes": {
+    "conditions": {
+      "type": "component",
+      "repeatable": true,
+      "component": "cartographie.condition_simple"
+    }
+  }
+}

--- a/back/strapi/components/cartographie/regle-champ.json
+++ b/back/strapi/components/cartographie/regle-champ.json
@@ -1,0 +1,19 @@
+{
+  "collectionName": "components_cartographie_regle_champs",
+  "info": {
+    "name": "Regle Champ",
+    "icon": "cog",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "conditions": {
+      "type": "component",
+      "repeatable": false,
+      "component": "cartographie.conditions_collection"
+    },
+    "valeur": {
+      "type": "string"
+    }
+  }
+}

--- a/back/strapi/components/cartographie/regles-champs.js
+++ b/back/strapi/components/cartographie/regles-champs.js
@@ -1,0 +1,25 @@
+const CartographiePoi = require("../../api/cartographie-poi/models/cartographie-poi.settings");
+
+const champs = Object.keys(CartographiePoi.attributes).filter(
+  (champ) => !champ.match(/^cartographie_/)
+);
+
+module.exports = {
+  collectionName: "components_cartographie_regles_champs",
+  info: {
+    name: "regles champs",
+    icon: "cogs",
+    description: "",
+  },
+  options: {},
+  attributes: Object.fromEntries(
+    champs.map((champ) => [
+      champ,
+      {
+        type: "component",
+        repeatable: true,
+        component: "cartographie.regle-champ",
+      },
+    ])
+  ),
+};

--- a/back/strapi/config/functions/cron.js
+++ b/back/strapi/config/functions/cron.js
@@ -10,4 +10,41 @@
  * See more details here: https://strapi.io/documentation/developer-docs/latest/concepts/configurations.html#cron-tasks
  */
 
-module.exports = {};
+const CartographieGeocodesService = require("../../api/cartographie-geocode/services");
+const CartographieSourcesService = require("../../api/cartographie-source/services");
+
+module.exports = {
+  // every 10 secondes
+  "*/20 * * * * *": async () => {
+    try {
+      const processedGeocodes = await CartographieGeocodesService.processMissingGeocodes();
+
+      console.log("[cron] geocode processed:", processedGeocodes, "item(s)");
+    } catch (e) {
+      console.error(`[cron] geocode error: ${e.message}`);
+      console.error(e.stack)
+    }
+
+    try {
+      const processedReverseGeocodes = await CartographieGeocodesService.processMissingAdresses();
+
+      console.log("[cron] reverse geocode processed:", processedReverseGeocodes, "item(s)");
+    } catch (e) {
+      console.error(`[cron] reverse geocode error: ${e.message}`);
+      console.error(e.stack)
+    }
+
+    //  },
+    //  // every minute
+    //  "*/10 * * * * *": async () => {
+
+    try {
+      const processedSource = await CartographieSourcesService.processUnprocessedSources();
+
+      console.log("[cron] carto-source processed:", processedSource, "item");
+    } catch (e) {
+      console.error(`[cron] geocode error: ${e.message}`);
+      console.error(e.stack)
+    }
+  },
+};

--- a/back/strapi/config/middleware.js
+++ b/back/strapi/config/middleware.js
@@ -1,0 +1,11 @@
+module.exports = {
+  settings: {
+    parser: {
+      enabled: true,
+      multipart: true,
+      formidable: {
+        maxFileSize: 1024 * 1024 * 1024, // 1 gb
+      },
+    },
+  },
+};

--- a/back/strapi/config/server.js
+++ b/back/strapi/config/server.js
@@ -3,6 +3,10 @@ module.exports = ({ env }) => ({
     auth: {
       secret: env("ADMIN_JWT_SECRET", "723ca8c711f1305897c937a5985c378f"),
     },
+    watchIgnoreFiles: ["**/*.csv", "**/#*#", "**/*~"],
+  },
+  cron: {
+    enabled: true,
   },
   host: env("HOST", "0.0.0.0"),
   port: env.int("PORT", 1337),

--- a/back/strapi/package.json
+++ b/back/strapi/package.json
@@ -17,10 +17,15 @@
   "dependencies": {
     "@ckeditor/ckeditor5-build-classic": "^27.1.0",
     "@ckeditor/ckeditor5-react": "^3.0.2",
+    "addok-geocode-stream": "risseraka/addok-geocode-stream#feat-reverse-geocode-fix-results",
     "axios": "^0.21.1",
+    "csv-string": "^4.0.1",
+    "csvtojson": "^2.0.10",
     "date-fns": "^2.21.1",
     "knex": "^0.95",
     "pg": "latest",
+    "react-color": "^2.19.3",
+    "slugify": "^1.5.3",
     "strapi": "^3.6.0",
     "strapi-admin": "^3.6.0",
     "strapi-connector-bookshelf": "^3.6.0",
@@ -31,7 +36,9 @@
     "strapi-plugin-graphql": "^3.6.0",
     "strapi-plugin-upload": "^3.6.0",
     "strapi-plugin-users-permissions": "^3.6.0",
-    "strapi-utils": "^3.6.0"
+    "strapi-utils": "^3.6.0",
+    "stream-chain": "^2.2.4",
+    "stream-json": "^1.7.1"
   },
   "author": {
     "name": "Fabrique des ministères sociaux"
@@ -52,6 +59,7 @@
     "eslint-plugin-jest": "^24.3.5",
     "jest": "^26.6.3",
     "node-fetch": "^2.6.1",
+    "pg-copy-streams": "^5.1.1",
     "prettier": "^2.2.1"
   }
 }

--- a/back/strapi/scripts/annuaire-beta-format-to-csv.js
+++ b/back/strapi/scripts/annuaire-beta-format-to-csv.js
@@ -1,0 +1,63 @@
+const fs = require("fs");
+const path = require("path");
+const { AsyncParser } = require("json2csv");
+
+const loadJsonFile = (filePath) => JSON.parse(fs.readFileSync(filePath));
+
+const SOURCES_PATH = "./sources/annuaire-beta";
+const FILE_NAME = "dataset.json";
+
+const formatAnnuaireBeta = (feature) => {
+  try {
+    const { coordinates: [longitude, latitude] } = feature.geometry || { coordinates: [] };
+    const { properties } = feature || {};
+
+    return {
+      longitude,
+      latitude,
+      ...properties,
+    };
+  } catch (e) {
+    console.error(e, feature);
+    return null;
+  }
+};
+
+const main = async () => {
+  console.log("geojsons loading...");
+
+  const features = loadJsonFile(path.join(SOURCES_PATH, FILE_NAME));
+  if (!features.length) return;
+
+  const json2csv = new AsyncParser(
+    {},
+    { objectMode: true, transforms: [formatAnnuaireBeta] }
+  );
+
+  const writeStream = fs.createWriteStream(
+    path.join(SOURCES_PATH, `${path.basename(FILE_NAME, ".json")}.csv`)
+  );
+
+  json2csv.processor.pipe(writeStream);
+
+  let loaded = 0;
+
+  for (const feature of features) {
+    const formated = formatAnnuaireBeta(feature);
+    if (!formated) continue;
+
+    json2csv.input.push(formated);
+
+    loaded += 1;
+  }
+
+  json2csv.input.push(null);
+
+  writeStream.on("finish", () =>
+    console.log("[annuaire beta] features, loaded:", loaded)
+  );
+};
+
+main()
+  .catch(console.error)
+  .finally(() => {});

--- a/back/strapi/scripts/annuaire-beta-format.js
+++ b/back/strapi/scripts/annuaire-beta-format.js
@@ -1,0 +1,66 @@
+const fs = require("fs");
+const path = require("path");
+
+const loadJsonFile = (filePath) => JSON.parse(fs.readFileSync(filePath));
+
+const SOURCES_PATH = "./sources/annuaire-beta";
+
+const types = ["pmi", "caf"];
+
+const formatAnnuaireBeta = (feature) => {
+  try {
+    if (!types.includes(feature.properties.pivotLocal)) return;
+
+    const { geometry, properties } = feature;
+
+    const {
+      coordinates: [latitude, longitude],
+    } = geometry || {};
+
+    const { pivotLocal: type, nom, adresses = [] } = properties || {};
+
+    const adressePhysique = adresses.length
+      ? adresses.find((a) => a.type === "physique") || {}
+      : adresses;
+
+    const { codePostal: code_postal, commune } = adressePhysique;
+
+    return {
+      type,
+      nom,
+      code_postal,
+      commune,
+      latitude,
+      longitude,
+      sources: [{ name: "annuaire-beta", data: feature }],
+    };
+  } catch (e) {
+    console.error(e);
+    return null;
+  }
+};
+
+const main = async () => {
+  console.log("geojsons loading...");
+
+  const filesNames = fs.readdirSync(SOURCES_PATH);
+
+  const geojsons = filesNames.flatMap((fileName) => {
+    console.log("geojson reading...", fileName);
+
+    const file = loadJsonFile(path.join(SOURCES_PATH, fileName));
+
+    return file.map(formatAnnuaireBeta).filter((e) => e);
+  });
+
+  console.log("[annuaire beta] geojsons, loaded:", geojsons.length);
+
+  fs.writeFileSync(
+    path.join("seeds", "structures.json"),
+    JSON.stringify(geojsons, null, 2)
+  );
+};
+
+main()
+  .catch(console.error)
+  .finally(() => {});

--- a/back/strapi/scripts/annuaire-sante-format.js
+++ b/back/strapi/scripts/annuaire-sante-format.js
@@ -1,0 +1,136 @@
+const fs = require("fs");
+const path = require("path");
+const csvtojson = require("csvtojson");
+
+const loadJsonFile = (filePath) => JSON.parse(fs.readFileSync(filePath));
+
+const SOURCES_PATH = "./sources/annuaire-sante";
+
+const FILE_NAME_REG = /PS_LibreAcces_Personne_activite_/;
+
+const professions = [
+  {
+    type: "sage-femme",
+    cond: [
+      {
+        key: "Libellé profession",
+        val: "Sage-Femme",
+      },
+    ],
+    count: 0,
+    stream: null,
+    parse: true,
+  },
+  {
+    type: "pediatre",
+    cond: [
+      {
+        key: "Libellé savoir-faire",
+        val: "Pédiatrie",
+      },
+    ],
+    count: 0,
+    stream: null,
+    parse: true,
+  },
+  {
+    type: "infirmier",
+    cond: [
+      {
+        key: "Libellé profession",
+        val: "Infirmier",
+      },
+    ],
+    count: 0,
+    stream: null,
+    parse: true,
+  },
+  {
+    type: "medecin",
+    cond: [
+      {
+        key: "Libellé profession",
+        val: "Médecin",
+      },
+    ],
+    count: 0,
+    stream: null,
+    parse: true,
+  },
+];
+
+const formatProfessionnel = (professionnel, profession) => {
+  const type = profession.type;
+  const nom = `${professionnel["Prénom d'exercice"]} ${professionnel["Nom d'exercice"]}`;
+  const code_postal = professionnel["Code postal (coord. structure)"];
+  const commune = professionnel["Libellé commune (coord. structure)"];
+
+  return {
+    type,
+    nom,
+    code_postal,
+    commune,
+    sources: [{ name: "annuaire-sante", data: professionnel }],
+  };
+};
+
+const filterData = (professions) => (data) =>
+  professions.find(({ type, cond }) =>
+    cond.every(({ key, val }) => data[key] === val)
+  );
+
+const openStreams = (professions) =>
+  professions.forEach((profession) => {
+    const targetPath = path.join(SOURCES_PATH, `${profession.type}.ndjson`);
+
+    profession.stream = fs.createWriteStream(targetPath);
+  });
+
+const getFilePath = (fileNameRegExp) => {
+  const filesNames = fs.readdirSync(SOURCES_PATH);
+
+  const fileName = filesNames.find((fileName) =>
+    fileName.match(fileNameRegExp)
+  );
+  const filePath = path.join(SOURCES_PATH, fileName);
+
+  return filePath;
+};
+
+const main = async (professions) => {
+  console.log("geojsons loading...");
+
+  const filePath = getFilePath(FILE_NAME_REG);
+  const readStream = fs.createReadStream(filePath);
+
+  //  professions = professions.slice(-1);
+
+  openStreams(professions);
+
+  const findProfession = filterData(professions);
+
+  csvtojson({ delimiter: "|", flatKeys: true })
+    .fromStream(readStream)
+    .on("data", (data) => {
+      const json = JSON.parse(data);
+
+      const profession = findProfession(json);
+      if (!profession || !profession.parse) return;
+
+      const professionnel = formatProfessionnel(json, profession);
+
+      profession.count += 1;
+
+      console.log(profession.type, profession.count);
+
+      const str = JSON.stringify(professionnel);
+
+      profession.stream.write(`${str}\n`);
+
+      profession.parse = profession.count < 1000;
+    });
+};
+
+main(professions)
+  .catch(console.error)
+  .finally(() => {});

--- a/back/strapi/scripts/auto-insert.js
+++ b/back/strapi/scripts/auto-insert.js
@@ -1,0 +1,288 @@
+require("dotenv").config();
+const fs = require("fs");
+const path = require("path");
+const csvtojson = require("csvtojson");
+const { Pool, Query } = require("pg");
+const { detect: detectDelimiter } = require("csv-string");
+const copyFrom = require("pg-copy-streams").from;
+
+let dbClient;
+
+const getFilePath = (sourceDir, fileNameRegExp) => {
+  const filesNames = fs.readdirSync(sourceDir);
+
+  const fileName = filesNames.find((fileName) =>
+    fileName.match(fileNameRegExp)
+  );
+  if (!fileName) return null;
+
+  const filePath = path.join(sourceDir, fileName);
+
+  return filePath;
+};
+
+const sqlCreateTableFormatColumns = (columns) =>
+  columns
+    .map((c, i) => {
+      const type = "text";
+
+      return `"${c || "field" + i}" ${type}`;
+    })
+    .join(",\n    ");
+
+const sqlCreateTable = (tableName, columns) => `
+  DROP TABLE IF EXISTS import_${tableName};
+
+  CREATE TABLE import_${tableName} (
+    ${sqlCreateTableFormatColumns(columns)}
+  );
+`;
+
+const sqlCopyCsv = (tableName, delimiter) => `
+  COPY import_${tableName}
+  FROM STDIN
+  DELIMITER '${delimiter}'
+  CSV HEADER;
+`;
+
+const csvStreamToDb = ({ tableName, dbClient, readStream, delimiter }) =>
+  new Promise(async (resolve, reject) => {
+    console.log(`[${tableName}] streaming to db`);
+
+    const query = copyFrom(sqlCopyCsv(tableName, delimiter));
+    const stream = dbClient.query(query);
+
+    stream.on("error", reject).on("finish", resolve);
+
+    readStream.on("error", reject).pipe(query);
+  });
+
+const csvDetectColumns = (string, options) =>
+  new Promise((resolve, reject) => {
+    const stream = csvtojson(options)
+      .on("error", reject)
+      .on("header", (columns) => {
+        stream.end();
+
+        if (!columns || !columns.length)
+          return reject(new Error("impossible error: no header"));
+
+        resolve(columns);
+      });
+    stream.write(string);
+  });
+
+const csvReadFirstLine = async (filePath) =>
+  new Promise((resolve, reject) => {
+    let line = "";
+    let pos = 0;
+    let index = 0;
+
+    const stream = fs
+      .createReadStream(filePath)
+      .on("data", (data) => {
+        index = data.indexOf("\n");
+
+        line += data.toString();
+
+        index !== -1 ? stream.close() : (pos += data.length);
+      })
+      .on("close", () => {
+        resolve(line.slice(0, pos + index));
+      })
+      .on("error", reject);
+  });
+
+const csvDelimiterDetect = async (filePath, options = {}) => {
+  const line = await csvReadFirstLine(filePath);
+
+  const delimiter = detectDelimiter(line);
+
+  const columns = await csvDetectColumns(line, {
+    ...options,
+    delimiter,
+  });
+
+  if (!columns.length) {
+    return reject(new Error(`${filePath} no columns, abort`));
+  }
+
+  return { delimiter, columns }
+};
+
+const csvProcess = async (dbClient, filePath, tableName) => {
+  const { delimiter, columns } = await csvDelimiterDetect(filePath);
+
+  console.log(
+    `[${tableName}] finished processing ${filePath}, delimiter = "${delimiter}"`
+  );
+  console.log(`[${tableName}] columns = ${columns.join(", ")}`);
+
+  console.log(`[${tableName}] drop / creating table`);
+  await dbClient.query(sqlCreateTable(tableName, columns));
+
+  const readStream = fs.createReadStream(filePath);
+
+  await csvStreamToDb({ tableName, dbClient, readStream, delimiter });
+};
+
+const jsonLoad = (filePath) => JSON.parse(fs.readFileSync(filePath));
+
+const sqlInsertFormatValues = (columns, obj) =>
+  columns
+    .map((column) => {
+      let value = obj[column];
+
+      if (typeof value === "object") value = JSON.stringify(value);
+      if (value === undefined) value = "";
+
+      return typeof value === "string"
+        ? `'${value.replace(/'/g, "''")}'`
+        : value;
+    })
+    .join(", ");
+
+const sqlInsertFormatValuesArray = (columns, valuesArray) =>
+  valuesArray
+    .map((arr) => `(${sqlInsertFormatValues(columns, arr)})`)
+    .join(",\n    ");
+
+const sqlInsertValuesArray = (tableName, columns, valuesArray) => `
+  INSERT INTO import_${tableName}
+  VALUES
+    ${sqlInsertFormatValuesArray(columns, valuesArray)};
+`;
+
+const jsonColumnsProcess = (dataArray) =>
+  Object.keys(
+    dataArray.reduce(
+      (columns, obj) =>
+        Object.keys(obj).reduce((columns, key) => {
+          columns[key] = true;
+          return columns;
+        }, columns),
+      {}
+    )
+  );
+
+const jsonInsert = async (dbClient, tableName, dataArray) => {
+  console.log(`[${tableName}] drop / creating table`);
+
+  console.log(dataArray.length);
+
+  const columns = jsonColumnsProcess(dataArray);
+  console.log([...columns]);
+
+  const sqlCreate = sqlCreateTable(tableName, columns);
+
+  await dbClient.query(sqlCreate);
+
+  const sql = sqlInsertValuesArray(tableName, columns, dataArray);
+
+  console.log(sql);
+
+  await dbClient.query(sql);
+};
+
+const geojsonFormatFeature = ({
+  geometry: { coordinates } = { coordinates: [] },
+  properties = {},
+}) => ({
+  ...properties,
+  coordinates: coordinates || [],
+});
+
+const batchSize = 1000;
+
+const geojsonFeaturesProcess = async (dbClient, tableName, features) => {
+  const featuresBuffer = [];
+
+  console.log(tableName, "features:", features.length);
+
+  for (const feature of features) {
+    featuresBuffer.push(geojsonFormatFeature(feature));
+
+    if (featuresBuffer.length >= batchSize) {
+      console.log(featuresBuffer);
+
+      await jsonInsert(dbClient, tableName, featuresBuffer);
+
+      featuresBuffer.length = 0;
+    }
+  }
+
+  if (featuresBuffer.length) {
+    await jsonInsert(dbClient, tableName, featuresBuffer);
+  }
+};
+
+const geojsonProcess = async (dbClient, filePath, tableName) => {
+  const geojson = jsonLoad(filePath);
+
+  const features =
+    geojson.type === "FeatureCollection" ? geojson.features : geojson;
+
+  await geojsonFeaturesProcess(dbClient, tableName, features);
+};
+
+const jsonProcess = async (dbClient, filePath, tableName) => {
+  const json = jsonLoad(filePath);
+
+  const obj = Array.isArray(json) ? json[0] : json;
+
+  if (obj.type === "Feature") {
+    return await geojsonFeaturesProcess(dbClient, tableName, json);
+  }
+
+  const columns = Object.keys(obj);
+
+  console.log("json col", columns);
+};
+
+const fileProcess = async (dbClient, filePath) => {
+  const tableName = filePath.split("/")[1].replace(/-/, "_");
+  const extension = path.extname(filePath);
+
+  console.log(`[${tableName}] ${extension} loading...`, filePath);
+
+  if (extension === ".geojson") {
+    await geojsonProcess(dbClient, filePath, tableName);
+  } else if (extension === ".json") {
+    await jsonProcess(dbClient, filePath, tableName);
+  } else {
+    await csvProcess(dbClient, filePath, tableName);
+  }
+};
+
+const main = async () => {
+  if (process.argv.length < 3)
+    return console.log("usage: node auto-insert FILE [FILE2 FILE3]");
+
+  let dbClient;
+
+  try {
+    const filePath = process.argv[2];
+
+    const pool = new Pool({
+      host: process.env.DATABASE_HOST,
+      port: process.env.DATABASE_PORT,
+      database: process.env.DATABASE_NAME,
+      user: process.env.DATABASE_USERNAME,
+      password: process.env.DATABASE_PASSWORD,
+    });
+
+    dbClient = await pool.connect();
+
+    for (const filePath of process.argv.slice(2)) {
+      await fileProcess(dbClient, filePath);
+    }
+  } catch (e) {
+    console.error(e);
+  } finally {
+    if (dbClient) {
+      dbClient.end();
+    }
+  }
+};
+
+main();

--- a/back/strapi/scripts/finess-format.js
+++ b/back/strapi/scripts/finess-format.js
@@ -1,0 +1,51 @@
+const fs = require("fs");
+const path = require("path");
+const csvtojson = require("csvtojson");
+
+const loadJsonFile = (filePath) => JSON.parse(fs.readFileSync(filePath));
+
+const SOURCES_PATH = "./sources/finess";
+const FILE_PATH = "finess-clean.csv";
+
+const formatStructure = (structure) => {
+  const type = structure.type;
+  const nom = structure.rslongue;
+
+  const [, code_postal, ...communeParts] = structure.ligneacheminement.match(/^(.{5}) (.+)/);
+
+  const commune = communeParts.join(' ')
+
+  return {
+    type,
+    nom,
+    code_postal,
+    commune,
+    sources: [{ name: "finess", data: structure }],
+  };
+};
+
+const main = async () => {
+  console.log("csv loading...");
+
+  const filePath = path.join(SOURCES_PATH, FILE_PATH);
+  const readStream = fs.createReadStream(filePath);
+
+  const targetPath = path.join(SOURCES_PATH, 'finess.ndjson');
+  const writeStream = fs.createWriteStream(targetPath);
+
+  let i = 0;
+
+  csvtojson({ delimiter: ";", flatKeys: true })
+    .fromStream(readStream)
+    .on("data", (data) => {
+      i += 1;
+
+      const structure = formatStructure(JSON.parse(data))
+
+      writeStream.write(`${JSON.stringify(structure)}\n`);
+    });
+};
+
+main()
+  .catch(console.error)
+  .finally(() => {});

--- a/back/strapi/scripts/geocode.js
+++ b/back/strapi/scripts/geocode.js
@@ -1,0 +1,24 @@
+const { createGeocodeStream: streamGeocode } = require("addok-geocode-stream");
+
+const SERVICE_URL = "https://api-adresse.data.gouv.fr";
+
+const main = () =>
+  new Promise((resolve, reject) => {
+    const stream = streamGeocode(SERVICE_URL, {
+      columns: ['address'],
+      bucketSize: 100,
+    });
+
+    stream
+      .on("data", (data) => {
+        console.log({ data });
+      })
+      .on("error", reject)
+      .on("finish", resolve);
+
+    stream.write({ address: "AVENUE JEAN HAMEAU Teste-de-Buch" });
+    stream.write({ address: "aosifnqoei nq314106y4h08 asmsgiggegqeipngipengpiengpieqngpiqe" });
+    stream.end();
+  });
+
+main().catch(console.error);

--- a/back/strapi/scripts/insert-csv.js
+++ b/back/strapi/scripts/insert-csv.js
@@ -1,0 +1,150 @@
+require("dotenv").config();
+const fs = require("fs");
+const path = require("path");
+const csvtojson = require("csvtojson");
+const { Client } = require("pg");
+
+const dbConnect = async () => {
+  const dbClient = new Client({
+    host: process.env.DATABASE_HOST,
+    port: process.env.DATABASE_PORT,
+    database: process.env.DATABASE_NAME,
+    user: process.env.DATABASE_USERNAME,
+    password: process.env.DATABASE_PASSWORD,
+  });
+
+  await dbClient.connect();
+
+  return dbClient;
+};
+
+const getFilePath = (sourceDir, fileNameRegExp) => {
+  const filesNames = fs.readdirSync(sourceDir);
+
+  const fileName = filesNames.find((fileName) =>
+    fileName.match(fileNameRegExp)
+  );
+  if (!fileName) return null;
+
+  const filePath = path.join(sourceDir, fileName);
+
+  return filePath;
+};
+
+const sqlInsertFormatValuesAsArray = (values) =>
+  values.map((v) => `'${v.replace(/'/g, "''")}'`).join(", ");
+
+const sqlInsertFormatValuesAsString = (values) =>
+  values.slice(1, values.length - 2);
+
+const sqlInsertFormatValues = (values) =>
+  `(${
+    typeof values === "string"
+      ? sqlInsertFormatValuesAsString(values)
+      : sqlInsertFormatValuesAsArray(values)
+  })`;
+
+const sqlInsertValues = (tableName, values) => `
+  INSERT INTO ${tableName}
+  VALUES ${sqlInsertFormatValues(values)};
+`;
+
+const sqlInsertFormatValuesArray = (valuesArray) =>
+  valuesArray.map(sqlInsertFormatValues).join(",\n    ");
+
+const sqlInsertValuesArray = (tableName, valuesArray) => `
+  INSERT INTO ${tableName}
+  VALUES
+    ${sqlInsertFormatValuesArray(valuesArray)};
+`;
+
+const sqlCreateFormatColumns = (columns) =>
+  columns.map((c, i) => `"${c || "field" + i}" text`).join(",\n    ");
+
+const sqlCreateTable = (tableName, columns) => `
+  DROP TABLE IF EXISTS import_${tableName};
+
+  CREATE TABLE import_${tableName} (
+    ${sqlCreateFormatColumns(columns)}
+  );
+`;
+
+const csvProcess = (tableName, csvStream, dbClient) =>
+  new Promise((resolve, reject) => {
+    console.log("processing csv data...");
+
+    const state = {
+      created: false,
+      finished: false,
+      header: null,
+      buffer: [],
+    };
+
+    csvStream
+      .on("error", reject)
+      .on("finish", (error) => {
+        console.log(
+          "finish event",
+          state.buffer.length,
+          "items",
+          ", error:",
+          !!error
+        );
+
+        if (state.buffer.length) {
+        }
+
+        error ? reject(error) : resolve();
+      })
+      .on("header", async (header) => {
+        console.log('header:', header)
+
+        state.header = header;
+
+        if (false)
+        csvStream.on('data', (data) => {
+          console.log('data')
+        })
+      });
+  });
+
+let dbClient;
+
+const run = async () => {
+  console.log("csv loading...");
+
+  const SOURCES_PATH = "./sources/annuaire-sante";
+
+  const FILE_NAME_REG = /PS_LibreAcces_Personne_activite_/;
+
+  const tableName = "import_annuaire_sante";
+  const delimiter = "|";
+
+  const filePath = getFilePath(SOURCES_PATH, FILE_NAME_REG);
+  if (!filePath) return;
+
+  console.log("found csv:", filePath);
+
+  dbClient = await dbConnect();
+
+  const csvStream = csvtojson({
+    delimiter,
+    flatKeys: true,
+    output: "csv",
+  });
+
+  csvStream.fromStream(fs.createReadStream(filePath));
+
+  await csvProcess(tableName, csvStream, dbClient);
+
+  console.log("finished processing csv");
+};
+
+const main = () =>
+  run()
+    .catch(console.error)
+    .finally(() => {
+      dbClient && dbClient.end();
+    });
+
+main();

--- a/back/strapi/scripts/json-stream.js
+++ b/back/strapi/scripts/json-stream.js
@@ -1,0 +1,40 @@
+const { chain } = require("stream-chain");
+const { parser } = require("stream-json/Parser");
+const { pick } = require("stream-json/filters/Pick");
+const { filter } = require("stream-json/filters/Filter");
+const { streamArray } = require("stream-json/streamers/StreamArray");
+const { streamObject } = require("stream-json/streamers/StreamObject");
+const { streamValues } = require("stream-json/streamers/StreamValues");
+const { Readable, Writable, Duplex, Transform } = require("stream");
+
+const BatchStream = require("batch-stream");
+
+const batch = new BatchStream()
+
+console.log(batch instanceof BatchStream);
+console.log(batch instanceof Transform);
+console.log(batch instanceof Object);
+
+process.exit(0);
+
+const fs = require("fs");
+
+const filePath =
+  process.argv[2] ||
+  "sources/umap-maternites/umap_maternites_en_france.geojson";
+
+const pipeline = chain([
+  fs.createReadStream(filePath),
+  parser(),
+  ...(filePath.match(/geojson/)
+    ? [pick({ filter: "features" }), streamArray()]
+    : [streamArray()]),
+]);
+
+let objectCounter = 0;
+pipeline.on("data", (data) => {
+  ++objectCounter;
+
+  console.log(data);
+});
+pipeline.on("end", () => console.log(`Found ${objectCounter} objects.`));

--- a/back/strapi/scripts/seed-stream.js
+++ b/back/strapi/scripts/seed-stream.js
@@ -1,0 +1,118 @@
+const fs = require("fs");
+const path = require("path");
+const { Transform } = require("stream");
+const Strapi = require("strapi");
+const ndjson = require("ndjson");
+
+const SEED_DIR = "seeds";
+
+const plural = (str) => `${str}s`.replace(/ss$/, "s");
+
+const models = [
+  {
+    model: "professionnel",
+    dir: "annuaire-sante",
+    files: ["infirmier", "sage-femme", "medecin", "pediatre"],
+  },
+];
+
+let strapi;
+let knex;
+
+const seedStream = (strapiModel, { file, stream }, model) =>
+  new Promise((resolve, reject) => {
+    let count = 0;
+
+    stream
+      .pipe(ndjson.parse())
+      .pipe(
+        new Transform({
+          objectMode: true,
+          transform: async (seed, encoding, callback) => {
+            await strapiModel.create(seed);
+
+            count += 1;
+
+            if (count % 100 === 0) {
+              console.log(
+                `inserted ${count} ${file} in ${model} model`
+              );
+            }
+
+            callback();
+          },
+        })
+      )
+      .on("data", (seed) => {})
+      .on("error", reject)
+      .on("end", async () => {
+        console.log(`finished, inserted ${count} ${file} in ${model} model`);
+
+        resolve();
+      });
+  });
+
+const importSeedStream = async ({ model, streams }) => {
+  const strapiModel = strapi.query(model);
+
+  console.log(`${model}: truncating table`);
+  await strapiModel.delete();
+
+  const modelEscaped = model.replace(/-/g, "_");
+
+  console.log(`${model}: resetting table sequence`);
+  await knex.raw(`ALTER SEQUENCE ${plural(modelEscaped)}_id_seq RESTART`);
+
+  console.log(`${model}: streaming item(s)`);
+
+  for (const stream of streams) {
+    await seedStream(strapiModel, stream, model);
+  }
+};
+
+const loadSeedsStreams = (models) =>
+  models.map(({ model, dir, files }) => ({
+    model,
+    streams: files.map((file) => ({
+      file,
+      stream: fs.createReadStream(
+        path.join(SEED_DIR, dir || "", `${file}.ndjson`)
+      ),
+    })),
+  }));
+
+const initKnex = () => (knex = strapi.connections.default);
+
+const initStrapi = async () => {
+  console.log("init strapi instance... (takes a few seconds)");
+  strapi = await Strapi().load();
+};
+
+const main = async (items) => {
+  if (items.length > 0) {
+    items = items.filter((model) => models.indexOf(model) !== -1);
+
+    if (items.length === 0) {
+      console.log("nothing to seed, exiting");
+      return;
+    }
+  } else {
+    items = models;
+  }
+
+  console.log("seeding:", items.map((i) => i.model).join(", "));
+
+  await initStrapi();
+  initKnex();
+
+  const seeds = loadSeedsStreams(items);
+
+  for (const seed of seeds) await importSeedStream(seed);
+};
+
+main(process.argv.slice(2))
+  .catch(console.error)
+  .finally(() => {
+    console.log("shutting down strapi instance");
+    strapi && strapi.stop(0);
+  });

--- a/back/strapi/scripts/seed.js
+++ b/back/strapi/scripts/seed.js
@@ -12,7 +12,7 @@ const models = [
   "etape",
   "evenement",
   "article",
-  "questionnaire-epds",
+  "questionnaire-epds"
 ];
 
 let strapi;

--- a/back/strapi/scripts/umap-materintes-format-to-csv.js
+++ b/back/strapi/scripts/umap-materintes-format-to-csv.js
@@ -1,0 +1,63 @@
+const fs = require("fs");
+const path = require("path");
+const { AsyncParser } = require("json2csv");
+
+const loadJsonFile = (filePath) => JSON.parse(fs.readFileSync(filePath));
+
+const SOURCES_PATH = "./sources/maternites";
+const FILE_NAME = "umap_maternites_en_france.geojson";
+
+const formatAnnuaireBeta = (feature) => {
+  try {
+    const { coordinates: [longitude, latitude] } = feature.geometry || { coordinates: [] };
+    const { properties } = feature || {};
+
+    return {
+      longitude,
+      latitude,
+      ...properties,
+    };
+  } catch (e) {
+    console.error(e, feature);
+    return null;
+  }
+};
+
+const main = async () => {
+  console.log("geojson loading...");
+
+  const { features } = loadJsonFile(path.join(SOURCES_PATH, FILE_NAME));
+  if (!features.length) return;
+
+  const json2csv = new AsyncParser(
+    {},
+    { objectMode: true, transforms: [formatAnnuaireBeta] }
+  );
+
+  const writeStream = fs.createWriteStream(
+    path.join(SOURCES_PATH, `${path.basename(FILE_NAME, ".geojson")}.csv`)
+  );
+
+  json2csv.processor.pipe(writeStream);
+
+  let loaded = 0;
+
+  for (const feature of features) {
+    const formated = formatAnnuaireBeta(feature);
+    if (!formated) continue;
+
+    json2csv.input.push(formated);
+
+    loaded += 1;
+  }
+
+  json2csv.input.push(null);
+
+  writeStream.on("finish", () =>
+    console.log("[materintes] features, loaded:", loaded)
+  );
+};
+
+main()
+  .catch(console.error)
+  .finally(() => {});


### PR DESCRIPTION
- Importer un fichier en créant une Cartographie-Source dans le backoffice ;
- Aller sur `/graphql` ;
- Faire une requête :

```graphql
{
  searchStructures(perimetre: [6, 47, 7, 48]) {
    nom
    type
    commune
  }
}
```

Ex : http://localhost:1337/graphql?query=%7B%0A%20%20searchStructures(perimetre%3A%20%5B6%2C%2047%2C%207%2C%2048%5D)%20%7B%0A%20%20%20%20nom%0A%20%20%20%20type%0A%20%20%20%20commune%0A%20%20%7D%0A%7D%0A