### PR TITLE
fix(articles): fix condition description

### DIFF
--- a/front/screens/ListArticles.tsx
+++ b/front/screens/ListArticles.tsx
@@ -90,7 +90,7 @@ const ListArticles: FC<Props> = ({ navigation, route }) => {
     <ScrollView>
       <View style={styles.topContainer}>
         <SecondaryText style={styles.title}>{screenTitle}</SecondaryText>
-        {description && description.length > 0 && (
+        {Boolean(description) && description.length > 0 && (
           <SecondaryText style={styles.description}>
             {description}
           </SecondaryText>

--- a/front/screens/ListArticles.tsx
+++ b/front/screens/ListArticles.tsx
@@ -90,7 +90,7 @@ const ListArticles: FC<Props> = ({ navigation, route }) => {
     <ScrollView>
       <View style={styles.topContainer}>
         <SecondaryText style={styles.title}>{screenTitle}</SecondaryText>
-        {Boolean(description) && description.length > 0 && (
+        {description.length > 0 && (
           <SecondaryText style={styles.description}>
             {description}
           </SecondaryText>


### PR DESCRIPTION
Quand on arrive sur ListArticles, si la description n'est pas renseignée côté back, la valeur "description" est quand même retournée avec une chaîne vide, donc la condition `description.length > 0` est suffisante