### PR TITLE
feat(matomo): ajoute le tracking avec Matomo

### DIFF
--- a/.github/workflows/expo-build-dev.yml
+++ b/.github/workflows/expo-build-dev.yml
@@ -11,6 +11,8 @@ jobs:
     env:
       API_URL: ${{ secrets.API_URL }}
       CLEAR_STORAGE: ${{ secrets.CLEAR_STORAGE }}
+      MATOMO_APPLICATION_ID: ${{ secrets.MATOMO_APPLICATION_ID }}
+      MATOMO_URL: ${{ secrets.MATOMO_URL }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -33,6 +35,8 @@ jobs:
     env:
       API_URL: ${{ secrets.API_URL }}
       CLEAR_STORAGE: ${{ secrets.CLEAR_STORAGE }}
+      MATOMO_APPLICATION_ID: ${{ secrets.MATOMO_APPLICATION_ID }}
+      MATOMO_URL: ${{ secrets.MATOMO_URL }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/expo-build-prod.yml
+++ b/.github/workflows/expo-build-prod.yml
@@ -11,6 +11,8 @@ jobs:
     env:
       API_URL: ${{ secrets.API_URL }}
       CLEAR_STORAGE: ${{ secrets.CLEAR_STORAGE }}
+      MATOMO_APPLICATION_ID: ${{ secrets.MATOMO_APPLICATION_ID }}
+      MATOMO_URL: ${{ secrets.MATOMO_URL }}
       PLAY_STORE_API_KEY: ${{ secrets.PLAY_STORE_API_KEY }}
     steps:
       - uses: actions/checkout@v2
@@ -35,6 +37,8 @@ jobs:
     env:
       API_URL: ${{ secrets.API_URL }}
       CLEAR_STORAGE: ${{ secrets.CLEAR_STORAGE }}
+      MATOMO_APPLICATION_ID: ${{ secrets.MATOMO_APPLICATION_ID }}
+      MATOMO_URL: ${{ secrets.MATOMO_URL }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/expo-publish-dev.yml
+++ b/.github/workflows/expo-publish-dev.yml
@@ -16,6 +16,8 @@ jobs:
     env:
       API_URL: ${{ secrets.API_URL }}
       CLEAR_STORAGE: ${{ secrets.CLEAR_STORAGE }}
+      MATOMO_APPLICATION_ID: ${{ secrets.MATOMO_APPLICATION_ID }}
+      MATOMO_URL: ${{ secrets.MATOMO_URL }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/expo-publish-prod.yml
+++ b/.github/workflows/expo-publish-prod.yml
@@ -11,6 +11,8 @@ jobs:
     env:
       API_URL: ${{ secrets.API_URL }}
       CLEAR_STORAGE: ${{ secrets.CLEAR_STORAGE }}
+      MATOMO_APPLICATION_ID: ${{ secrets.MATOMO_APPLICATION_ID }}
+      MATOMO_URL: ${{ secrets.MATOMO_URL }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/front/.env.example
+++ b/front/.env.example
@@ -1,2 +1,4 @@
 API_URL=https://backoffice-preprod-les1000jours.dev2.fabrique.social.gouv.fr
 CLEAR_STORAGE=false
+MATOMO_APPLICATION_ID=43
+MATOMO_URL=https://matomo.fabrique.social.gouv.fr/

--- a/front/App.tsx
+++ b/front/App.tsx
@@ -12,7 +12,8 @@ import { StorageKeysConstants } from "./constants";
 import useCachedResources from "./hooks/useCachedResources";
 import useColorScheme from "./hooks/useColorScheme";
 import Navigation from "./navigation";
-import { StorageUtils } from "./utils";
+import { StorageUtils, TrackerUtils } from "./utils";
+import { MatomoProvider, useMatomo } from "matomo-tracker-react-native";
 
 const client = new ApolloClient({
   cache: new InMemoryCache(),
@@ -31,14 +32,16 @@ const App: FC = () => {
 
   // Load Custom Fonts (Icomoon)
   const [fontsLoaded, setFontsLoaded] = useState(false);
+  const { trackAppStart } = useMatomo();
 
   useEffect(() => {
+    trackAppStart();
     Font.loadAsync(customFonts)
       .then(() => {
         setFontsLoaded(true);
       })
       .catch((error) => {
-        console.log(error);
+        console.error(error);
       });
   }, []);
 
@@ -49,12 +52,14 @@ const App: FC = () => {
     return null;
   } else {
     return (
-      <ApolloProvider client={client}>
-        <SafeAreaProvider>
-          <Navigation colorScheme={colorScheme} />
-          <StatusBar />
-        </SafeAreaProvider>
-      </ApolloProvider>
+      <MatomoProvider instance={TrackerUtils.matomoInstance}>
+        <ApolloProvider client={client}>
+          <SafeAreaProvider>
+            <Navigation colorScheme={colorScheme} />
+            <StatusBar />
+          </SafeAreaProvider>
+        </ApolloProvider>
+      </MatomoProvider>
     );
   }
 };

--- a/front/package.json
+++ b/front/package.json
@@ -46,6 +46,7 @@
     "expo-web-browser": "~9.1.0",
     "graphql": "^15.5.0",
     "lodash": "^4.17.21",
+    "matomo-tracker-react-native": "^0.2.3",
     "react": "17.0.1",
     "react-dom": "17.0.1",
     "react-native": "https://github.com/expo/react-native/archive/sdk-40.0.1.tar.gz",

--- a/front/screens/ArticleDetail.tsx
+++ b/front/screens/ArticleDetail.tsx
@@ -15,11 +15,10 @@ import TextHtml from "../components/article/TextHtml";
 import Thematics from "../components/article/Thematics";
 import Title from "../components/article/Title";
 import BackButton from "../components/BackButton";
-import { CommonText, SecondaryText } from "../components/StyledText";
+import { CommonText, SecondaryText } from "../components";
 import { View } from "../components/Themed";
-import Colors from "../constants/Colors";
-import Labels from "../constants/Labels";
-import { FontWeight } from "../constants/Layout";
+import { Colors, Labels } from "../constants";
+import { FontWeight } from "../constants";
 import type {
   Article,
   ArticleInShortItem,
@@ -27,6 +26,8 @@ import type {
   Step,
   TabHomeParamList,
 } from "../types";
+import { useMatomo } from "matomo-tracker-react-native";
+import { TrackerUtils } from "../utils";
 
 interface Props {
   route: RouteProp<{ params: { id: number; step: Step } }, "params">;
@@ -34,6 +35,7 @@ interface Props {
 }
 
 const ArticleDetail: FC<Props> = ({ route, navigation }) => {
+  const { trackScreenView } = useMatomo();
   const articleId = route.params.id;
   const screenTitle = route.params.step.nom;
   const description = route.params.step.description;
@@ -99,6 +101,9 @@ const ArticleDetail: FC<Props> = ({ route, navigation }) => {
   if (error) return <CommonText>{Labels.errorMsg}</CommonText>;
 
   const result = data as { article: Article };
+  trackScreenView(
+    `${TrackerUtils.TrackingEvent.ARTICLE} : ${result.article.titre}`
+  );
   setInShortArray(result.article);
   setLinksArray(result.article);
   return (

--- a/front/screens/ListArticles.tsx
+++ b/front/screens/ListArticles.tsx
@@ -11,7 +11,7 @@ import { Image, ListItem } from "react-native-elements";
 
 import Filters from "../components/article/Filters";
 import Button from "../components/form/Button";
-import { CommonText, SecondaryText } from "../components/StyledText";
+import { CommonText, SecondaryText } from "../components";
 import { View } from "../components/Themed";
 import {
   Colors,
@@ -22,7 +22,8 @@ import {
   Sizes,
 } from "../constants";
 import type { Article, Step, TabHomeParamList } from "../types";
-
+import { useMatomo } from "matomo-tracker-react-native";
+import { TrackerUtils } from "../utils";
 interface Props {
   navigation: StackNavigationProp<TabHomeParamList, "listArticles">;
   route: RouteProp<{ params: { step: Step } }, "params">;
@@ -32,6 +33,11 @@ peut-être que ça devrait être au back, lorsqu'il retourne les articles, de di
 const ETAPE_ENFANT_3_PREMIERS_MOIS = 6;
 
 const ListArticles: FC<Props> = ({ navigation, route }) => {
+  const { trackScreenView } = useMatomo();
+  trackScreenView(
+    `${TrackerUtils.TrackingEvent.ARTICLE_LIST} : ${route.params.step.nom}`
+  );
+
   const screenTitle = route.params.step.nom;
   const description = route.params.step.description;
   const stepIsFirstThreeMonths =

--- a/front/screens/Onboarding.tsx
+++ b/front/screens/Onboarding.tsx
@@ -12,7 +12,7 @@ import SecondSlideImage from "../assets/images/Humaaans_Sitting.svg";
 import Button from "../components/form/Button";
 import HeaderApp from "../components/HeaderApp";
 import Icomoon, { IcomoonIcons } from "../components/Icomoon";
-import { CommonText, SecondaryText } from "../components/StyledText";
+import { CommonText, SecondaryText } from "../components";
 import { View } from "../components/Themed";
 import {
   Colors,
@@ -24,7 +24,8 @@ import {
   StorageKeysConstants,
 } from "../constants";
 import type { RootStackParamList } from "../types";
-import { StorageUtils } from "../utils";
+import { StorageUtils, TrackerUtils } from "../utils";
+import { useMatomo } from "matomo-tracker-react-native";
 
 type ProfileScreenNavigationProp = StackNavigationProp<
   RootStackParamList,
@@ -42,6 +43,8 @@ interface SlideView {
 }
 
 const Onboarding: FC<Props> = ({ navigation }) => {
+  const { trackScreenView } = useMatomo();
+  trackScreenView(TrackerUtils.TrackingEvent.ONBOARDING);
   const slideViews: SlideView[] = [
     {
       description: Labels.onboarding.slidesText[0].description,

--- a/front/screens/Profile.tsx
+++ b/front/screens/Profile.tsx
@@ -15,7 +15,7 @@ import ProfileImage from "../assets/images/Humaaans_Space_1.svg";
 import { Button, Checkbox, Datepicker } from "../components";
 import HeaderApp from "../components/HeaderApp";
 import Icomoon, { IcomoonIcons } from "../components/Icomoon";
-import { CommonText } from "../components/StyledText";
+import { CommonText } from "../components";
 import { View } from "../components/Themed";
 import {
   Colors,
@@ -30,12 +30,16 @@ import {
 } from "../constants";
 import type { RootStackParamList, UserContext, UserSituation } from "../types";
 import { StorageUtils } from "../utils";
+import { useMatomo } from "matomo-tracker-react-native";
+import { TrackerUtils } from "../utils";
 
 interface Props {
   navigation: StackNavigationProp<RootStackParamList, "profile">;
 }
 
 const Profile: FC<Props> = ({ navigation }) => {
+  const { trackScreenView } = useMatomo();
+  trackScreenView(TrackerUtils.TrackingEvent.PROFILE);
   const image = <ProfileImage />;
 
   const defaultUserContext: UserContext = {

--- a/front/screens/TabCalendarScreen.tsx
+++ b/front/screens/TabCalendarScreen.tsx
@@ -10,7 +10,7 @@ import { Button } from "../components";
 import Agenda from "../components/calendar/agenda";
 import Events from "../components/calendar/events";
 import Icomoon, { IcomoonIcons } from "../components/Icomoon";
-import { CommonText } from "../components/StyledText";
+import { CommonText } from "../components";
 import { Text, View } from "../components/Themed";
 import {
   Colors,
@@ -21,9 +21,12 @@ import {
   StorageKeysConstants,
 } from "../constants";
 import type { Event } from "../types";
-import { StorageUtils } from "../utils";
+import { StorageUtils, TrackerUtils } from "../utils";
+import { useMatomo } from "matomo-tracker-react-native";
 
 const TabCalendarScreen: FC = () => {
+  const { trackScreenView } = useMatomo();
+  trackScreenView(TrackerUtils.TrackingEvent.CALENDAR);
   const [childBirthday, setChildBirthday] = React.useState("");
   const [isModeAgenda, setIsModeAgenda] = React.useState(true);
 

--- a/front/screens/TabHomeScreen.tsx
+++ b/front/screens/TabHomeScreen.tsx
@@ -7,19 +7,23 @@ import * as React from "react";
 import { ActivityIndicator, StyleSheet, Text } from "react-native";
 import { ScrollView } from "react-native-gesture-handler";
 
-import { CommonText, SecondaryText } from "../components/StyledText";
+import { CommonText, SecondaryText } from "../components";
 import { View } from "../components/Themed";
 import TimelineStep from "../components/timeline/TimlineStep";
 import Colors from "../constants/Colors";
 import Labels from "../constants/Labels";
-import { FontWeight } from "../constants/Layout";
+import { FontWeight } from "../constants";
 import type { Step, TabHomeParamList } from "../types";
+import { useMatomo } from "matomo-tracker-react-native";
+import { TrackerUtils } from "../utils";
 
 interface Props {
   navigation: StackNavigationProp<TabHomeParamList, "listArticles">;
 }
 
 const TabHomeScreen: FC<Props> = ({ navigation }) => {
+  const { trackScreenView } = useMatomo();
+  trackScreenView(TrackerUtils.TrackingEvent.HOME);
   const screenTitle = Labels.timeline.title;
   const description = Labels.timeline.description;
   const ALL_STEPS = gql`

--- a/front/utils/index.ts
+++ b/front/utils/index.ts
@@ -1,5 +1,6 @@
 import * as DataFetchingUtils from "./dataFetching.util";
 import * as EpdsSurveyUtils from "./epdsSurvey.util";
 import * as StorageUtils from "./storage.util";
+import * as TrackerUtils from "./tracker.util";
 
-export { DataFetchingUtils, EpdsSurveyUtils, StorageUtils };
+export { DataFetchingUtils, EpdsSurveyUtils, StorageUtils, TrackerUtils };

--- a/front/utils/tracker.util.ts
+++ b/front/utils/tracker.util.ts
@@ -1,0 +1,15 @@
+import MatomoTracker from "matomo-tracker-react-native";
+
+export const matomoInstance = new MatomoTracker({
+  urlBase: process.env.MATOMO_URL,
+  siteId: process.env.MATOMO_APPLICATION_ID,
+});
+
+export enum TrackingEvent {
+  ONBOARDING = "Onboarding",
+  PROFILE = "Profil",
+  HOME = "Accueil",
+  ARTICLE_LIST = "Liste d'articles",
+  ARTICLE = "Article",
+  CALENDAR = "Calendrier",
+}

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -9840,6 +9840,11 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+matomo-tracker-react-native@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/matomo-tracker-react-native/-/matomo-tracker-react-native-0.2.3.tgz#ce800bf5e31fc1099460f5c212cc54fb192edc32"
+  integrity sha512-VV1izaajMDAiEGMVdmyjvr2anqB98FycZBKhWYRLLt4T8wxL+O+bbHweHPmC41Bma/u5bHzXJPe5MSve107UfA==
+
 md5-file@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/md5-file/-/md5-file-3.2.3.tgz#f9bceb941eca2214a4c0727f5e700314e770f06f"


### PR DESCRIPTION
Le package `react-native-matomo` n'est pas compatible avec Expo, donc j'ai utilisé `matomo-tracker-react-native` (https://github.com/donni106/matomo-tracker-react-native). 
Il n'y a pas de package `@types/matomo-tracker-react-native` donc j'ai ajouté moi-même un typings.

Il y a deux nouvelles variables d'environnement ajoutées dans les secrets du repo et dans la CI : MATOMO_URL et MATOMO_APPLICATION_ID