### PR TITLE
fix(android): ajout l'apiKey pour Google Maps

### DIFF
--- a/front/app.config.js
+++ b/front/app.config.js
@@ -5,6 +5,11 @@ export default {
         backgroundColor: "#FFFFFF",
         foregroundImage: "./assets/images/adaptive-icon.png",
       },
+      config: {
+        googleMaps: {
+          apiKey: "AIzaSyBh4I3B8R5Qrf2Sj-maDxwrbQXVcHuDlR0",
+        },
+      },
       package: "com.fabrique.millejours",
       versionCode: 8,
     },

--- a/front/app.config.js
+++ b/front/app.config.js
@@ -7,7 +7,7 @@ export default {
       },
       config: {
         googleMaps: {
-          apiKey: "AIzaSyBh4I3B8R5Qrf2Sj-maDxwrbQXVcHuDlR0",
+          apiKey: process.env.GOOGLE_MAPS_API_KEY,
         },
       },
       package: "com.fabrique.millejours",


### PR DESCRIPTION
Closes #356 
Doc pour ajouter la clé API dans l'app : https://docs.expo.io/versions/latest/sdk/map-view/#deploying-google-maps-to-a-standalone-app