### PR TITLE
fix(carto): filtre obligatoire + pagination locale

### DIFF
--- a/front/components/aroundMe/fetchPoisCoords.component.tsx
+++ b/front/components/aroundMe/fetchPoisCoords.component.tsx
@@ -55,18 +55,19 @@ const FetchPoisCoords: React.FC<Props> = ({
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (!savedTypeFilter || savedTypeFilter.length === 0) {
         chooseFilterMessage();
-      } else {
-        const variables = {
-          lat1: topLeftPoint.latitude,
-          lat2: bottomRightPoint.latitude,
-          long1: topLeftPoint.longitude,
-          long2: bottomRightPoint.longitude,
-          types: savedTypeFilter,
-        };
-        getPoisByGpsCoords({
-          variables,
-        });
+        return;
       }
+
+      const variables = {
+        lat1: topLeftPoint.latitude,
+        lat2: bottomRightPoint.latitude,
+        long1: topLeftPoint.longitude,
+        long2: bottomRightPoint.longitude,
+        types: savedTypeFilter,
+      };
+      getPoisByGpsCoords({
+        variables,
+      });
     };
     void searchByGPSCoords();
   }, [triggerSearchByGpsCoords]);

--- a/front/components/aroundMe/fetchPoisCoords.component.tsx
+++ b/front/components/aroundMe/fetchPoisCoords.component.tsx
@@ -17,6 +17,7 @@ interface Props {
   postalCode: string;
   region: Region;
   setFetchedPois: (pois: CartographiePoisFromDB[]) => void;
+  chooseFilterMessage: () => void;
 }
 
 const FetchPoisCoords: React.FC<Props> = ({
@@ -24,6 +25,7 @@ const FetchPoisCoords: React.FC<Props> = ({
   triggerSearchByGpsCoords,
   region,
   setFetchedPois,
+  chooseFilterMessage,
 }) => {
   const [getPoisByGpsCoords] = useLazyQuery(
     DatabaseQueries.AROUNDME_POIS_BY_GPSCOORDS,
@@ -50,16 +52,21 @@ const FetchPoisCoords: React.FC<Props> = ({
       const savedTypeFilter: string[] = await StorageUtils.getObjectValue(
         StorageKeysConstants.cartoFilterKey
       );
-      const variables = {
-        lat1: topLeftPoint.latitude,
-        lat2: bottomRightPoint.latitude,
-        long1: topLeftPoint.longitude,
-        long2: bottomRightPoint.longitude,
-        types: savedTypeFilter,
-      };
-      getPoisByGpsCoords({
-        variables,
-      });
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (!savedTypeFilter || savedTypeFilter.length === 0) {
+        chooseFilterMessage();
+      } else {
+        const variables = {
+          lat1: topLeftPoint.latitude,
+          lat2: bottomRightPoint.latitude,
+          long1: topLeftPoint.longitude,
+          long2: bottomRightPoint.longitude,
+          types: savedTypeFilter,
+        };
+        getPoisByGpsCoords({
+          variables,
+        });
+      }
     };
     void searchByGPSCoords();
   }, [triggerSearchByGpsCoords]);

--- a/front/constants/Labels.ts
+++ b/front/constants/Labels.ts
@@ -7,6 +7,8 @@ export default {
     addressesListLabelEnd:
       "points d'intérêts qui correspondent à vos critères :",
     addressesListLabelStart: "Il y a",
+    chooseFilter:
+      "Veuillez choisir un au moins un élément dans le filtre afin de lancer la recherche",
     filter: {
       healthProfessional: "Professionnels de santé",
       steps: "Étapes du parcours 1000 jours",

--- a/front/constants/aroundMe.constants.ts
+++ b/front/constants/aroundMe.constants.ts
@@ -15,7 +15,7 @@ export const INITIAL_REGION = {
 };
 
 export const POSTAL_CODE_MAX_LENGTH = 5;
-export const NUMBER_MAX_MARKERS_ON_MAP = 20;
+export const PAGINATION_NUMBER_ADDRESSES_LIST = 20;
 
 export const getApiUrlWithParam = (postalCode: string): string =>
   `https://api-adresse.data.gouv.fr/search/?q=${postalCode}&type=municipality&limit=1`;

--- a/front/screens/aroundMe/aroundMeFilter.component.tsx
+++ b/front/screens/aroundMe/aroundMeFilter.component.tsx
@@ -62,22 +62,27 @@ const AroundMeFilter: React.FC<Props> = ({ visible, showModal, hideModal }) => {
       const savedFilters: string[] = await StorageUtils.getObjectValue(
         StorageKeysConstants.cartoFilterKey
       );
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      if (savedFilters?.length > 0 && fetchedFiltersFromDB) {
+      if (fetchedFiltersFromDB) {
+        fetchedFiltersFromDB.professionnels.forEach(
+          (filter) => (filter.active = false)
+        );
         fetchedFiltersFromDB.structures.forEach(
           (filter) => (filter.active = false)
         );
 
-        setFetchedFiltersFromDB({
-          professionnels: checkSavedFiltersInFetchedFilters(
-            savedFilters,
-            fetchedFiltersFromDB.professionnels
-          ),
-          structures: checkSavedFiltersInFetchedFilters(
-            savedFilters,
-            fetchedFiltersFromDB.structures
-          ),
-        });
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        if (savedFilters?.length > 0) {
+          setFetchedFiltersFromDB({
+            professionnels: checkSavedFiltersInFetchedFilters(
+              savedFilters,
+              fetchedFiltersFromDB.professionnels
+            ),
+            structures: checkSavedFiltersInFetchedFilters(
+              savedFilters,
+              fetchedFiltersFromDB.structures
+            ),
+          });
+        }
       }
       setShowModalContent(true);
     };

--- a/front/screens/aroundMe/aroundMeFilter.component.tsx
+++ b/front/screens/aroundMe/aroundMeFilter.component.tsx
@@ -25,10 +25,11 @@ import { StorageUtils } from "../../utils";
 
 interface Props {
   visible: boolean;
+  showModal: () => void;
   hideModal: (filterWasSaved: boolean) => void;
 }
 
-const AroundMeFilter: React.FC<Props> = ({ visible, hideModal }) => {
+const AroundMeFilter: React.FC<Props> = ({ visible, showModal, hideModal }) => {
   const [poiTypesAndCategories, setPoiTypesAndCategories] =
     useState<PoiTypeFromDB[]>();
 
@@ -36,6 +37,17 @@ const AroundMeFilter: React.FC<Props> = ({ visible, hideModal }) => {
     useState<CartoFilters>();
   const [poiTypeArray, setPoiTypeArray] = useState<string[]>([]);
   const [showModalContent, setShowModalContent] = useState(false);
+
+  useEffect(() => {
+    const checkIfSavedFilters = async () => {
+      const savedFilters: string[] = await StorageUtils.getObjectValue(
+        StorageKeysConstants.cartoFilterKey
+      );
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (!savedFilters || savedFilters.length === 0) showModal();
+    };
+    void checkIfSavedFilters();
+  }, []);
 
   useEffect(() => {
     if (poiTypesAndCategories && poiTypesAndCategories.length > 0)

--- a/front/screens/aroundMe/slidingUpPanelAddressesList.component.tsx
+++ b/front/screens/aroundMe/slidingUpPanelAddressesList.component.tsx
@@ -64,15 +64,14 @@ const SlidingUpPanelAddressesList: React.FC<Props> = ({ poisArray }) => {
         </CommonText>
         <ScrollView
           onScroll={({ nativeEvent }) => {
-            if (isCloseToBottom(nativeEvent)) {
-              const newEndIndex = currentEndIndex + currentEndIndex;
-              setPoisToDisplay(
-                poisToDisplay.concat(
-                  poisArray.slice(currentEndIndex, newEndIndex)
-                )
-              );
-              setCurrentEndIndex(newEndIndex);
-            }
+            if (!isCloseToBottom(nativeEvent)) return;
+            const newEndIndex = currentEndIndex + currentEndIndex;
+            setPoisToDisplay(
+              poisToDisplay.concat(
+                poisArray.slice(currentEndIndex, newEndIndex)
+              )
+            );
+            setCurrentEndIndex(newEndIndex);
           }}
         >
           {poisToDisplay.map((poi, poiIndex) => (

--- a/front/screens/aroundMe/tabAroundMeScreen.component.tsx
+++ b/front/screens/aroundMe/tabAroundMeScreen.component.tsx
@@ -71,9 +71,7 @@ const TabAroundMeScreen: React.FC = () => {
       showSnackBarWithMessage(Labels.aroundMe.noAddressFound);
     }
     setPoisArrayInList(pois);
-    setPoisArrayOnMap(
-      pois.slice(0, AroundMeConstants.NUMBER_MAX_MARKERS_ON_MAP)
-    );
+    setPoisArrayOnMap(pois);
     setShowAddressesList(true);
   };
 
@@ -132,6 +130,9 @@ const TabAroundMeScreen: React.FC = () => {
         postalCode={postalCodeInput}
         region={region}
         setFetchedPois={handleFetchedPois}
+        chooseFilterMessage={() => {
+          showSnackBarWithMessage(Labels.aroundMe.chooseFilter);
+        }}
       />
       <View style={styles.topContainer}>
         <TitleH1
@@ -235,6 +236,9 @@ const TabAroundMeScreen: React.FC = () => {
         )}
       <AroundMeFilter
         visible={showFilter}
+        showModal={() => {
+          setShowFilter(true);
+        }}
         hideModal={(filterWasSaved: boolean) => {
           setShowFilter(false);
           if (filterWasSaved) {


### PR DESCRIPTION
Closes #394 
Modifications apportées : 
- Si aucun type n'est choisi dans le filtre, celui-ci s'ouvre automatiquement au lancement de la carto. Si l'utilisateur ferme le filtre sans avoir choisi de type, un message s'affiche (voir la capture sur le chan 1000j_core_brique_carto)
- La liste des adresses n'en affiche que 20 au début, puis les 20 suivantes s'affichent au fur et à mesure du scroll. La carto reste ainsi fluide