### PR TITLE
fix(carto): activation geoloc + affichage filtre si plus de 20 POI

### DIFF
--- a/front/components/aroundMe/fetchPoisCoords.component.tsx
+++ b/front/components/aroundMe/fetchPoisCoords.component.tsx
@@ -62,8 +62,6 @@ const FetchPoisCoords: React.FC<Props> = ({
       );
     const cartoIsFirstLaunch = isFirstLaunch === null;
 
-    console.log("fetchPoisCoords");
-    console.log(cartoIsFirstLaunch);
     const savedFilters: CartoFilterStorage | undefined =
       await StorageUtils.getObjectValue(StorageKeysConstants.cartoFilterKey);
     if (

--- a/front/components/aroundMe/fetchPoisCoords.component.tsx
+++ b/front/components/aroundMe/fetchPoisCoords.component.tsx
@@ -1,6 +1,6 @@
 import { useLazyQuery } from "@apollo/client";
 import * as React from "react";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import type { Region } from "react-native-maps";
 
 import {
@@ -18,6 +18,7 @@ interface Props {
   region: Region;
   setFetchedPois: (pois: CartographiePoisFromDB[]) => void;
   chooseFilterMessage: () => void;
+  searchIsReady: boolean;
 }
 
 const FetchPoisCoords: React.FC<Props> = ({
@@ -26,22 +27,8 @@ const FetchPoisCoords: React.FC<Props> = ({
   region,
   setFetchedPois,
   chooseFilterMessage,
+  searchIsReady,
 }) => {
-  const [getPoisCountByGpsCoords] = useLazyQuery(
-    DatabaseQueries.AROUNDME_POIS_COUNT_BY_GPSCOORDS,
-    {
-      fetchPolicy: "no-cache",
-      onCompleted: async (data) => {
-        const { searchPoisCount } = data as {
-          searchPoisCount: number;
-        };
-        await searchByGPSCoords(
-          searchPoisCount > AroundMeConstants.MAX_NUMBER_POI_WITHOUT_FILTER,
-          false
-        );
-      },
-    }
-  );
   const [getPoisByGpsCoords] = useLazyQuery(
     DatabaseQueries.AROUNDME_POIS_BY_GPSCOORDS,
     {
@@ -55,7 +42,7 @@ const FetchPoisCoords: React.FC<Props> = ({
     }
   );
 
-  const searchByGPSCoords = async (withFilter: boolean, getCount: boolean) => {
+  const searchByGPSCoords = async () => {
     const topLeftPoint = AroundMeUtils.getLatLngPoint(
       region,
       AroundMeConstants.LatLngPointType.topLeft
@@ -65,46 +52,48 @@ const FetchPoisCoords: React.FC<Props> = ({
       AroundMeConstants.LatLngPointType.bottomRight
     );
 
-    let paramsVariables = null;
+    const isFirstLaunch: boolean | null = await StorageUtils.getObjectValue(
+      StorageKeysConstants.cartoIsFirstLaunch
+    );
+    if (isFirstLaunch === null)
+      await StorageUtils.storeObjectValue(
+        StorageKeysConstants.cartoIsFirstLaunch,
+        true
+      );
+    const cartoIsFirstLaunch = isFirstLaunch === null;
 
-    if (withFilter) {
-      const savedFilters: CartoFilterStorage | undefined =
-        await StorageUtils.getObjectValue(StorageKeysConstants.cartoFilterKey);
-      if (
-        !savedFilters ||
+    console.log("fetchPoisCoords");
+    console.log(cartoIsFirstLaunch);
+    const savedFilters: CartoFilterStorage | undefined =
+      await StorageUtils.getObjectValue(StorageKeysConstants.cartoFilterKey);
+    if (
+      !cartoIsFirstLaunch &&
+      (!savedFilters ||
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         (savedFilters &&
           StringUtils.stringArrayIsNullOrEmpty(savedFilters.types) &&
-          StringUtils.stringArrayIsNullOrEmpty(savedFilters.etapes))
-      ) {
-        chooseFilterMessage();
-        return;
-      }
-      paramsVariables = {
-        etapes: savedFilters.etapes,
-        types: savedFilters.types,
-      };
+          StringUtils.stringArrayIsNullOrEmpty(savedFilters.etapes)))
+    ) {
+      chooseFilterMessage();
+      return;
     }
 
     const variables = {
-      ...paramsVariables,
+      etapes: savedFilters?.etapes ? savedFilters.etapes : [],
       lat1: topLeftPoint.latitude,
       lat2: bottomRightPoint.latitude,
       long1: topLeftPoint.longitude,
       long2: bottomRightPoint.longitude,
+      types: savedFilters?.types ? savedFilters.types : [],
     };
-    if (getCount)
-      getPoisCountByGpsCoords({
-        variables,
-      });
-    else
-      getPoisByGpsCoords({
-        variables,
-      });
+    getPoisByGpsCoords({
+      variables,
+    });
   };
 
   useEffect(() => {
-    void searchByGPSCoords(false, true);
+    if (!searchIsReady) return;
+    void searchByGPSCoords();
   }, [triggerSearchByGpsCoords]);
 
   return <>{children}</>;

--- a/front/components/aroundMe/fetchPoisCoords.component.tsx
+++ b/front/components/aroundMe/fetchPoisCoords.component.tsx
@@ -60,6 +60,7 @@ const FetchPoisCoords: React.FC<Props> = ({
         StorageKeysConstants.cartoIsFirstLaunch,
         true
       );
+
     const cartoIsFirstLaunch = isFirstLaunch === null;
 
     const savedFilters: CartoFilterStorage | undefined =
@@ -91,6 +92,7 @@ const FetchPoisCoords: React.FC<Props> = ({
 
   useEffect(() => {
     if (!searchIsReady) return;
+
     void searchByGPSCoords();
   }, [triggerSearchByGpsCoords]);
 

--- a/front/constants/storageKeys.constants.ts
+++ b/front/constants/storageKeys.constants.ts
@@ -8,6 +8,7 @@ export const epdsQuestionIndexKey = "@epdsQuestionIndexKey";
 export const epdsSurveyCounterKey = "@epdsSurveyCounterKey";
 export const cartoFilterKey = "@cartoFilterKey";
 export const cartoSavedRegion = "@cartoSavedRegion";
+export const cartoIsFirstLaunch = "@cartoIsFirstLaunch";
 export const notifIdNextStep = "@notifIdNextStep";
 export const notifIdsEvents = "@notifIdsEvents";
 
@@ -20,6 +21,8 @@ export const allStorageKeys = [
   epdsQuestionAndAnswersKey,
   epdsQuestionIndexKey,
   cartoFilterKey,
+  cartoSavedRegion,
+  cartoIsFirstLaunch,
   notifIdNextStep,
   notifIdsEvents,
 ];

--- a/front/screens/aroundMe/aroundMeFilter.component.tsx
+++ b/front/screens/aroundMe/aroundMeFilter.component.tsx
@@ -37,11 +37,10 @@ import { StorageUtils, StringUtils } from "../../utils";
 
 interface Props {
   visible: boolean;
-  showModal: () => void;
   hideModal: (filterWasSaved: boolean) => void;
 }
 
-const AroundMeFilter: React.FC<Props> = ({ visible, showModal, hideModal }) => {
+const AroundMeFilter: React.FC<Props> = ({ visible, hideModal }) => {
   const [filterDataFromDb, setFilterDataFromDb] = useState<unknown>();
 
   const [fetchedFiltersFromDB, setFetchedFiltersFromDB] =
@@ -61,18 +60,6 @@ const AroundMeFilter: React.FC<Props> = ({ visible, showModal, hideModal }) => {
         etapes: StepFromDB[];
       };
       extractFilterData(cartographieTypes, etapes);
-
-      const savedFilters: CartoFilterStorage =
-        await StorageUtils.getObjectValue(StorageKeysConstants.cartoFilterKey);
-      if (
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        !savedFilters ||
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        (savedFilters &&
-          StringUtils.stringArrayIsNullOrEmpty(savedFilters.types) &&
-          StringUtils.stringArrayIsNullOrEmpty(savedFilters.etapes))
-      )
-        showModal();
     };
     void extractFilterDataAndCheckSavedFilters();
   }, [filterDataFromDb]);

--- a/front/screens/aroundMe/searchByPostalCode.component.tsx
+++ b/front/screens/aroundMe/searchByPostalCode.component.tsx
@@ -32,7 +32,7 @@ interface Props {
   setAndGoToNewRegion: (region: Region) => void;
   showSnackBarWithMessage: (message: string) => void;
   setIsLoading: (value: boolean) => void;
-  updateUserLocation: (coordinates: LatLng) => void;
+  updateUserLocation: (coordinates: LatLng | undefined) => void;
   setSearchIsReady: (value: boolean) => void;
 }
 
@@ -65,7 +65,7 @@ const SearchByPostalCode: React.FC<Props> = ({
       const currentLocation = await Location.getCurrentPositionAsync({});
       updateUserLocation(currentLocation.coords);
     } catch {
-      showSnackBarWithMessage(Labels.errorMsg);
+      updateUserLocation(undefined);
     }
 
     setIsLoading(false);

--- a/front/screens/aroundMe/searchByPostalCode.component.tsx
+++ b/front/screens/aroundMe/searchByPostalCode.component.tsx
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import * as Location from "expo-location";
 import * as React from "react";
+import { useEffect } from "react";
 import { Image, StyleSheet, TextInput, TouchableOpacity } from "react-native";
 import type { LatLng, Region } from "react-native-maps";
 import { HelperText } from "react-native-paper";
@@ -32,6 +33,7 @@ interface Props {
   showSnackBarWithMessage: (message: string) => void;
   setIsLoading: (value: boolean) => void;
   updateUserLocation: (coordinates: LatLng) => void;
+  setSearchIsReady: (value: boolean) => void;
 }
 
 const SearchByPostalCode: React.FC<Props> = ({
@@ -44,7 +46,13 @@ const SearchByPostalCode: React.FC<Props> = ({
   showSnackBarWithMessage,
   setIsLoading,
   updateUserLocation,
+  setSearchIsReady,
 }) => {
+  useEffect(() => {
+    setSearchIsReady(false);
+    void checkLocation();
+  }, []);
+
   const checkLocation = async () => {
     const { status } = await Location.requestForegroundPermissionsAsync();
     if (status !== Location.PermissionStatus.GRANTED) {
@@ -61,6 +69,7 @@ const SearchByPostalCode: React.FC<Props> = ({
     }
 
     setIsLoading(false);
+    setSearchIsReady(true);
   };
 
   const onPostalCodeChanged = (newPostalCode: string) => {

--- a/front/screens/aroundMe/tabAroundMeScreen.component.tsx
+++ b/front/screens/aroundMe/tabAroundMeScreen.component.tsx
@@ -98,7 +98,6 @@ const TabAroundMeScreen: React.FC = () => {
     const isFirstLaunch = await StorageUtils.getObjectValue(
       StorageKeysConstants.cartoIsFirstLaunch
     );
-    console.log(isFirstLaunch);
     if (
       isFirstLaunch &&
       pois.length >= AroundMeConstants.MAX_NUMBER_POI_WITHOUT_FILTER
@@ -233,10 +232,24 @@ const TabAroundMeScreen: React.FC = () => {
         }}
         showSnackBarWithMessage={showSnackBarWithMessage}
         setIsLoading={setIsLoading}
-        updateUserLocation={(coordinates: LatLng) => {
-          setSelectedPoiIndex(-1);
-          setCurrentUserLocation(coordinates);
-          moveMapToCoordinates(coordinates.latitude, coordinates.longitude);
+        updateUserLocation={async (coordinates: LatLng | undefined) => {
+          if (coordinates) {
+            setSelectedPoiIndex(-1);
+            setCurrentUserLocation(coordinates);
+            moveMapToCoordinates(coordinates.latitude, coordinates.longitude);
+          } else {
+            const savedRegion: Region | undefined = await StorageUtils.getObjectValue(
+                StorageKeysConstants.cartoSavedRegion
+              );
+            moveMapToCoordinates(
+              savedRegion?.latitude
+                ? savedRegion.latitude
+                : AroundMeConstants.COORDINATE_PARIS.latitude,
+              savedRegion?.longitude
+                ? savedRegion.longitude
+                : AroundMeConstants.COORDINATE_PARIS.longitude
+            );
+          }
           setMoveToRegionBecauseOfPCResearch(true);
         }}
         setSearchIsReady={setSearchIsReady}

--- a/front/screens/aroundMe/tabAroundMeScreen.component.tsx
+++ b/front/screens/aroundMe/tabAroundMeScreen.component.tsx
@@ -98,6 +98,7 @@ const TabAroundMeScreen: React.FC = () => {
     const isFirstLaunch = await StorageUtils.getObjectValue(
       StorageKeysConstants.cartoIsFirstLaunch
     );
+
     if (
       isFirstLaunch &&
       pois.length >= AroundMeConstants.MAX_NUMBER_POI_WITHOUT_FILTER
@@ -112,6 +113,7 @@ const TabAroundMeScreen: React.FC = () => {
       setShowAddressesList(true);
       setShowAddressDetails(false);
     }
+
     setIsLoading(false);
     void StorageUtils.storeObjectValue(
       StorageKeysConstants.cartoIsFirstLaunch,
@@ -238,16 +240,15 @@ const TabAroundMeScreen: React.FC = () => {
             setCurrentUserLocation(coordinates);
             moveMapToCoordinates(coordinates.latitude, coordinates.longitude);
           } else {
-            const savedRegion: Region | undefined = await StorageUtils.getObjectValue(
+            const savedRegion: Region | undefined =
+              await StorageUtils.getObjectValue(
                 StorageKeysConstants.cartoSavedRegion
               );
             moveMapToCoordinates(
-              savedRegion?.latitude
-                ? savedRegion.latitude
-                : AroundMeConstants.COORDINATE_PARIS.latitude,
-              savedRegion?.longitude
-                ? savedRegion.longitude
-                : AroundMeConstants.COORDINATE_PARIS.longitude
+              savedRegion?.latitude ??
+                AroundMeConstants.COORDINATE_PARIS.latitude,
+              savedRegion?.longitude ??
+                AroundMeConstants.COORDINATE_PARIS.longitude
             );
           }
           setMoveToRegionBecauseOfPCResearch(true);


### PR DESCRIPTION
Closes #502 

Changements apportés : 
- demande d'activation de la géolocalisation à chaque lancement de la carto (si l'utilisateur refuse, on va sur Paris ou la dernière région enregistrée) puis lancement d'une recherche
- au tout premier lancement de la carto (et puisque le filtre est vide), s'il y a moins de 20 POI, on affiche le filtre (pour les prochains lancements et si le filtre est toujours vide, on affiche simplement un message)