### PR TITLE
fix(ci): longer lifetime for develop branch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,8 +76,8 @@ Review develop:
     - if: "$PRODUCTION || $TRIGGER || $CI_COMMIT_TAG"
       when: never
     - if: "$CI_COMMIT_BRANCH == 'develop'"
-      when: always
-    - when: on_success
+      when: on_success
+    - when: never
   environment:
     auto_stop_in: 15 day
     name: ${CI_COMMIT_REF_NAME}${AUTO_DEVOPS_DEV_ENVIRONMENT_NAME}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,3 +58,28 @@ Restore preprod db:
       when: never
     - when: manual
     - when: never
+
+Review:
+  extends: .autodevops_review
+  # add an exception for the develop branch (permanent env)
+  rules:
+    - if: "$PRODUCTION || $TRIGGER || $CI_COMMIT_TAG"
+      when: never
+    - if: "$CI_COMMIT_BRANCH == 'develop'"
+      when: never
+    - when: on_success
+    
+# longer env lifetime for develop branch
+Review develop:
+  extends: .autodevops_review
+  rules:
+    - if: "$PRODUCTION || $TRIGGER || $CI_COMMIT_TAG"
+      when: never
+    - if: "$CI_COMMIT_BRANCH == 'develop'"
+      when: always
+    - when: on_success
+  environment:
+    auto_stop_in: 15 day
+    name: ${CI_COMMIT_REF_NAME}${AUTO_DEVOPS_DEV_ENVIRONMENT_NAME}
+    on_stop: Stop review
+    url: https://${CI_ENVIRONMENT_SLUG}-${CI_PROJECT_NAME}.${KUBE_INGRESS_BASE_DOMAIN}


### PR DESCRIPTION
ajoute un special case pour la branche "develop" que gitlab doit maintenir 15 jours après le dernier déploiement