### PR TITLE
feat(epds): réaffichage smiley pour les résultats

### DIFF
--- a/front/screens/epdsSurvey/epdsLightResult.component.tsx
+++ b/front/screens/epdsSurvey/epdsLightResult.component.tsx
@@ -6,6 +6,9 @@ import * as React from "react";
 import { useEffect, useState } from "react";
 import { ScrollView, StyleSheet } from "react-native";
 
+import IconeResultatBien from "../../assets/images/icone_resultats_bien.svg";
+import IconeResultatMoyen from "../../assets/images/icone_resultats_moyen.svg";
+import IconeResultatPasBien from "../../assets/images/icone_resultats_pasbien.svg";
 import { Button, CustomSnackbar, TitleH1 } from "../../components";
 import { SecondaryText } from "../../components/StyledText";
 import { View } from "../../components/Themed";
@@ -13,6 +16,7 @@ import {
   AroundMeConstants,
   Colors,
   DatabaseQueries,
+  EpdsConstants,
   FontWeight,
   Labels,
   Margins,
@@ -94,10 +98,30 @@ const EpdsLightResult: React.FC<Props> = ({
   // Delete saved storage keys for EPDS survey
   void EpdsSurveyUtils.removeEpdsStorageItems();
 
+  const getIcon = (icone: EpdsConstants.ResultIconValueEnum) => {
+    const iconsMap = new Map<
+      EpdsConstants.ResultIconValueEnum,
+      React.ReactNode
+    >();
+    iconsMap.set(EpdsConstants.ResultIconValueEnum.bien, <IconeResultatBien />);
+    iconsMap.set(
+      EpdsConstants.ResultIconValueEnum.moyen,
+      <IconeResultatMoyen />
+    );
+    iconsMap.set(
+      EpdsConstants.ResultIconValueEnum.pasBien,
+      <IconeResultatPasBien />
+    );
+    return iconsMap.get(icone);
+  };
+
   return (
     <>
       <ScrollView>
         <TitleH1 title={Labels.epdsSurveyLight.titleLight} animated={false} />
+        <View style={styles.rowView}>
+          <View>{getIcon(EpdsSurveyUtils.getResultIconLight(result))}</View>
+        </View>
         <SecondaryText style={[styles.text, styles.fontBold]}>
           {Labels.epdsSurveyLight.oserEnParler}
         </SecondaryText>
@@ -179,6 +203,7 @@ const styles = StyleSheet.create({
     padding: Paddings.default,
   },
   rowView: {
+    alignSelf: "center",
     flexDirection: "row",
   },
   stateOfMind: {

--- a/front/utils/epdsSurvey.util.ts
+++ b/front/utils/epdsSurvey.util.ts
@@ -158,6 +158,18 @@ export const getResultLabelAndStyleLight = (): EpdsResultData => {
   };
 };
 
+export const getResultIconLight = (
+  result: number
+): EpdsConstants.ResultIconValueEnum => {
+  if (result <= EpdsConstants.RESULT_WELL_VALUE) {
+    return EpdsConstants.ResultIconValueEnum.bien;
+  } else if (result <= EpdsConstants.RESULT_NOTSOWELL_VALUE) {
+    return EpdsConstants.ResultIconValueEnum.moyen;
+  } else {
+    return EpdsConstants.ResultIconValueEnum.pasBien;
+  }
+};
+
 export const getEachQuestionScore = (
   questionsAndAnswers: EpdsQuestionAndAnswers[]
 ): number[] => {


### PR DESCRIPTION
Closes #649 

J'ai volontairement repris et donc dupliqué du code du fichier `epdsResult.component.tsx` vers le `epdsLightResult.component.tsx`, c'est normal vu que le fichier "light" est temporaire et sera très potentiellement supprimé prochainement, quand on reviendra aux textes spécifiques au résultat EPDS