### PR TITLE
fix: rootless strapi container

### DIFF
--- a/back/strapi/.dockerignore
+++ b/back/strapi/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+.gitignore

--- a/back/strapi/.dockerignore
+++ b/back/strapi/.dockerignore
@@ -1,2 +1,3 @@
 Dockerfile
 .gitignore
+.dockerignore

--- a/back/strapi/Dockerfile
+++ b/back/strapi/Dockerfile
@@ -21,7 +21,8 @@ ENV NODE_ENV=production
 
 RUN yarn build
 
-RUN adduser --system --uid 1001 strapi
+RUN adduser --system --uid 1001 strapi && \
+    chown -R strapi /app
 USER 1001
 
 CMD ["yarn", "start"]

--- a/back/strapi/Dockerfile
+++ b/back/strapi/Dockerfile
@@ -21,8 +21,8 @@ ENV NODE_ENV=production
 
 RUN yarn build
 
-RUN adduser --system --uid 1001 strapi && \
-    chown -R strapi /app
+RUN adduser --uid 1001 strapi && \
+    chown -R strapi:strapi /app
 USER 1001
 
 CMD ["yarn", "start"]

--- a/back/strapi/Dockerfile
+++ b/back/strapi/Dockerfile
@@ -1,20 +1,27 @@
 FROM strapi/base:14
 
-RUN apt-get update
-
-RUN apt-get install -y libnss3 ca-certificates fonts-liberation libappindicator3-1 libasound2 libatk-bridge2.0-0 \
-  libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libglib2.0-0 libgtk-3-0 \
-  libnspr4 libnss3 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 \
-  libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 lsb-release wget xdg-utils
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+        libnss3 ca-certificates fonts-liberation libappindicator3-1 libasound2 libatk-bridge2.0-0 \
+        libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 \
+        libglib2.0-0 libgtk-3-0 libnspr4 libnss3 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 \
+        libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 \
+        libxi6 libxrandr2 libxrender1 libxss1 libxtst6 lsb-release wget xdg-utils && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
 COPY . .
 
-RUN yarn --production --frozen-lockfile --prefer-offline && yarn cache clean
+RUN yarn --production --frozen-lockfile --prefer-offline && \
+    yarn cache clean
 
 ENV NODE_ENV=production
 
 RUN yarn build
+
+RUN adduser --system --uid 1001 strapi
+USER 1001
 
 CMD ["yarn", "start"]


### PR DESCRIPTION
Permet d'exécuter le serveur Strapi sans qu'il ait les droits root dans son conteneur Docker, pour des raisons de sécurité sur le cluster Kubernetes.

Si quelqu'un veut s'occuper de tester que le backend marche normalement :grin: 