### PR TITLE
fix: prod BACKOFFICE_URL

### DIFF
--- a/.kube-workflow/prod/values.yaml
+++ b/.kube-workflow/prod/values.yaml
@@ -1,9 +1,10 @@
 global:
   namespace: les1000jours
+  host: "les1000jours.fabrique.social.gouv.fr"
 
 app-strapi:
   certSecretName: strapi-cache-crt
-  host: "backoffice-1000jours.fabrique.social.gouv.fr"
+  host: "backoffice-les1000jours.fabrique.social.gouv.fr"
   addVolumes:
     - uploads
   volumeMounts:


### PR DESCRIPTION
fix strapi BACKOFFICE_URL in prod to always use `backoffice-les1000jours.fabrique.social.gouv.fr`