### PR TITLE
fix(accessibility): focus map

### DIFF
--- a/front/src/components/aroundMe/aroundMeMap.component.tsx
+++ b/front/src/components/aroundMe/aroundMeMap.component.tsx
@@ -19,7 +19,7 @@ import {
   SCREEN_HEIGHT,
 } from "../../constants/platform.constants";
 import { useAccessibilityReader } from "../../hooks";
-import { Colors, Margins } from "../../styles";
+import { Colors, Margins, Paddings } from "../../styles";
 import {
   AroundMeUtils,
   KeyboardUtils,
@@ -274,6 +274,16 @@ const AroundMeMap: FC<ExtendedPropsForSimpleMap> = ({
         />
       </View>
       <View style={styles.map} onLayout={onViewMapLayout}>
+        <AroundMeMapHeader
+          headerStyle={styles.headerButtonsMapView}
+          displayMap
+          setDisplayMap={onDisplayMap}
+          relaunchSearch={onRelaunchSearch}
+          showRelaunchResearchButton={showRelaunchResearchButton}
+          setIsLoading={setIsLoading}
+          showDisplayListButton={showDisplayListButton}
+          hideDisplayListButton={isFromSimpleCarto}
+        />
         <MapView
           minZoomLevel={AroundMeConstants.MAPVIEW_MIN_ZOOM_LEVEL}
           ref={setMapViewRef}
@@ -315,16 +325,6 @@ const AroundMeMap: FC<ExtendedPropsForSimpleMap> = ({
             </Marker>
           )}
         </MapView>
-        <AroundMeMapHeader
-          headerStyle={styles.headerButtonsMapView}
-          displayMap
-          setDisplayMap={onDisplayMap}
-          relaunchSearch={onRelaunchSearch}
-          showRelaunchResearchButton={showRelaunchResearchButton}
-          setIsLoading={setIsLoading}
-          showDisplayListButton={showDisplayListButton}
-          hideDisplayListButton={isFromSimpleCarto}
-        />
         <CustomSnackbar
           isAccessibilityModeOn={isAccessibilityModeOn}
           visible={showSnackBar}
@@ -380,18 +380,19 @@ const styles = StyleSheet.create({
   headerButtonsMapView: {
     backgroundColor: "transparent",
     flexDirection: "row",
-    height: "15%",
     left: 0,
-    margin: Margins.smaller,
+    padding: Paddings.smaller,
     position: "absolute",
     right: 0,
     top: 0,
+    zIndex: 1,
   },
   mainContainer: {
     flex: 1,
   },
   map: {
     flex: 1,
+    marginTop: 1,
   },
 });
 

--- a/front/src/components/aroundMe/aroundMeMapHeader.component.tsx
+++ b/front/src/components/aroundMe/aroundMeMapHeader.component.tsx
@@ -177,19 +177,7 @@ const styles = StyleSheet.create({
   headerButtonsRightPartView: {
     alignItems: "flex-end",
     backgroundColor: "transparent",
-    justifyContent: "flex-end",
-    position: "absolute",
-    right: 0,
-  },
-  headerButtonsView: {
-    backgroundColor: "transparent",
-    flexDirection: "row",
-    height: "15%",
-    left: 0,
-    margin: Margins.smaller,
-    position: "absolute",
-    right: 0,
-    top: 0,
+    flexGrow: 1,
   },
 });
 

--- a/front/src/components/aroundMe/aroundMeMapHeader.component.tsx
+++ b/front/src/components/aroundMe/aroundMeMapHeader.component.tsx
@@ -76,7 +76,7 @@ const AroundMeMapHeader: FC<Props> = ({
 
   return (
     <>
-      <View style={headerStyle}>
+      <View style={[headerStyle, styles.headerBasic]}>
         <CustomButton
           buttonStyle={styles.headerButton}
           title={Labels.articleList.filters}
@@ -162,6 +162,9 @@ const AroundMeMapHeader: FC<Props> = ({
 const styles = StyleSheet.create({
   buttonMarginTop: {
     marginTop: Margins.smaller,
+  },
+  headerBasic: {
+    flexWrap: "wrap",
   },
   headerButton: {
     backgroundColor: Colors.white,


### PR DESCRIPTION
10.2 : (E08) => Dans la carte, il faut que les premières tabulations s'effectuent sur les boutons "filtrer", "afficher en liste" etc…

10.1 : (E08) => (iOS) L'ordre de tabulation n'est pas cohérent (voir détail dans le rapport) 
_**Je pense que ça correspond à l'item du dessus**_


Warning : 
(visible sur iOS) lorsque l'écran n'est pas assez large, les boutons de droite sont alignés mais mangés. Je propose donc cet modif pour ne pas faire trop de magouilles dans le css lorsque l'on veut placer tous le bloc : ![Capture d’écran 2022-08-19 à 15 24 48](https://user-images.githubusercontent.com/20834756/185628741-724f381e-0109-4ba4-80cd-236a28c0bf52.png)
