### PR TITLE
chore: release without bot token

### DIFF
--- a/.github/workflows/socialgouv-release.yml
+++ b/.github/workflows/socialgouv-release.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-        persist-credentials: false
+        ssh-key: ${{ secrets.DEPLOY_KEY }}
 
     - name: Semantic Release
       uses: cycjimmy/semantic-release-action@v2
@@ -25,4 +25,4 @@ jobs:
           @semantic-release/changelog@5.0.1
           @semantic-release/git@9.0.0
       env:
-        GITHUB_TOKEN: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Utiliser la **deploy key** dans le secrets du repo plutôt que le PAT du Social Groovy bot