### PR TITLE
fix(accessibility): label puce

### DIFF
--- a/front/src/components/article/links.component.tsx
+++ b/front/src/components/article/links.component.tsx
@@ -34,19 +34,18 @@ const Links: FC<Props> = ({ linksArray }) => {
       <SubTitle title={Labels.article.learnMoreAboutIt} />
       <View style={styles.linksContainer}>
         {_.filter(linksArray, "label").map((item, index) => (
-          <ListItem.Content key={index} style={[styles.linkContainer]}>
-            <SecondaryText
-              style={styles.dot}
-              importantForAccessibility="no"
-              accessibilityElementsHidden
-              accessible={false}
-            >
+          <ListItem.Content
+            key={index}
+            style={[styles.linkContainer]}
+            accessibilityRole="tab"
+          >
+            <SecondaryText style={styles.dot} accessibilityLabel="Puces">
               {SpecialChars.blackLargeCircle}
             </SecondaryText>
             <SecondaryText
-              accessibilityRole="link"
               style={styles.link}
               onPress={goToUrl(item.url)}
+              accessibilityRole="link"
             >
               {item.label}
             </SecondaryText>
@@ -60,7 +59,7 @@ const Links: FC<Props> = ({ linksArray }) => {
 const styles = StyleSheet.create({
   dot: {
     color: Colors.primaryBlue,
-    fontSize: Sizes.xxxxxs,
+    fontSize: Sizes.xxxxs,
     lineHeight: Sizes.lg,
     textAlignVertical: "top",
   },

--- a/front/src/components/html/li.component.tsx
+++ b/front/src/components/html/li.component.tsx
@@ -1,19 +1,38 @@
 import * as React from "react";
 import { StyleSheet } from "react-native";
 
-import { Paddings } from "../../styles";
+import SpecialChars from "../../constants/specialChars";
+import { Colors, Margins, Paddings, Sizes } from "../../styles";
 import type { TextProps } from "../baseComponents";
-import { SecondaryText } from "../baseComponents";
+import { SecondaryText, View } from "../baseComponents";
 
 const Li: React.FC<TextProps> = (props) => {
   const newProps = {
     ...props,
     children: `${props.children}`,
   };
-  return <SecondaryText {...newProps} style={[styles.li, props.style]} />;
+  return (
+    <View style={styles.content}>
+      <SecondaryText style={styles.dot} accessibilityLabel="Puces">
+        {SpecialChars.blackLargeCircle}
+      </SecondaryText>
+      <SecondaryText {...newProps} style={[styles.li, props.style]} />
+    </View>
+  );
 };
 
 const styles = StyleSheet.create({
+  content: {
+    display: "flex",
+    flexDirection: "row",
+  },
+  dot: {
+    color: Colors.primaryBlue,
+    fontSize: Sizes.xxxxs,
+    lineHeight: Sizes.lg,
+    marginRight: Margins.default,
+    textAlignVertical: "top",
+  },
   li: {
     paddingVertical: Paddings.smallest,
   },

--- a/front/src/utils/aroundMe/aroundMe.util.ts
+++ b/front/src/utils/aroundMe/aroundMe.util.ts
@@ -26,7 +26,7 @@ export const getPostalCodeCoords = async (
 
     return newCoords;
   } catch (error: unknown) {
-    console.log(error);
+    console.warn(error);
     return undefined;
   }
 };


### PR DESCRIPTION
En navigant sur le site de la W3C, j'ai parcouru le sommaire (qui est une liste) en mode accessible, et le lecteur d'écran dit : 
- `puces` : `mon label`

Donc j'ai fait un peu de bricolage en mettant des puces et `accessibilityLabel="Puces"` dessus pour avoir le même rendu au lecteur d'écran