### PR TITLE
Update strapi RAM request

### DIFF
--- a/.kontinuous/values.yaml
+++ b/.kontinuous/values.yaml
@@ -10,7 +10,7 @@ app-strapi:
   resources:
     requests:
       cpu: 0.5
-      memory: 256Mi
+      memory: 512Mi
     limits:
       cpu: 1
       memory: 1Gi


### PR DESCRIPTION
modify strapi RAM request from 256Mo to 512Mo

This has for effect to reduce the number of POD start with the HPA from 10 (max value) to 2 or 4