### PR TITLE
fix(ci-cd): use token-bureau

### DIFF
--- a/.github/workflows/socialgouv-release.yml
+++ b/.github/workflows/socialgouv-release.yml
@@ -5,11 +5,21 @@ on:
   push:
     branches: [master, alpha, beta, next]
 
+permissions:
+  id-token: write  # Required for OIDC token generation
+
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
     steps:
+
+    - name: Get GitHub App Token
+      id: token
+      uses: SocialGouv/token-bureau@main
+      with:
+        token-bureau-url: https://token-bureau.fabrique.social.gouv.fr
+        audience: socialgouv
 
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -25,4 +35,4 @@ jobs:
           @semantic-release/changelog@5.0.1
           @semantic-release/git@9.0.0
       env:
-        GITHUB_TOKEN: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+        GITHUB_TOKEN: ${{ steps.token.outputs.token }}


### PR DESCRIPTION
Migration vers le nouveau système "TokenBureau", le SOCIALGROOVYBOT_BOTO_PAT ne sera plus disponible à partir de février 2025, si vous voulez que vos workflows continuent à fonctionner correctement, vous devez merger cette PR.